### PR TITLE
Fix Loyola building offset and add OSM way IDs

### DIFF
--- a/app/src/main/java/com/example/myapplication/data/CampusData.kt
+++ b/app/src/main/java/com/example/myapplication/data/CampusData.kt
@@ -532,7 +532,7 @@ object CampusRepo {
 
     private val loyolaBuildings = listOf(
 
-        Building("Administration Building", "AD", 0,
+        Building("Administration Building", "AD", 111604324457,
             listOf(
             LatLng(45.4581785, -73.6394752),
             LatLng(45.4581606, -73.6394892),
@@ -591,7 +591,7 @@ object CampusRepo {
 
         )),
 
-        Building("BB Annex", "BB", 0,
+        Building("BB Annex", "BB", 604324439,
             listOf(
             LatLng(45.4598208, -73.6391704),
             LatLng(45.4597195, -73.6392492),
@@ -600,14 +600,14 @@ object CampusRepo {
 
         )),
 
-        Building("BH Annex", "BH", 0,listOf(
+        Building("BH Annex", "BH", 604324440,listOf(
             LatLng(45.4597913, -73.6390959),
             LatLng(45.4596919, -73.6391749),
             LatLng(45.4596624, -73.6390950),
             LatLng(45.4597641, -73.6390208)
         )),
 
-        Building("Communication Studies Building", "CC", 0,listOf(
+        Building("Communication Studies Building", "CC", 111604324456,listOf(
             LatLng(45.4584607, -73.6406749),
             LatLng(45.4583684, -73.6404372),
             LatLng(45.4583574, -73.6404459),
@@ -626,7 +626,7 @@ object CampusRepo {
             LatLng(45.4582011, -73.6405694)
         )),
 
-        Building("Communication Studies and Journalism", "CJ", 0,listOf(
+        Building("Communication Studies and Journalism", "CJ", 47332007,listOf(
             LatLng(45.4571693, -73.6403939),
             LatLng(45.4572802, -73.6406597),
             LatLng(45.4573061, -73.6406414),
@@ -664,7 +664,7 @@ object CampusRepo {
             LatLng(45.4574139, -73.6402070)
         )),
 
-        Building("Stinger Dome", "DO", 0,listOf(
+        Building("Stinger Dome", "DO", 129437736,listOf(
             LatLng(45.4583485, -73.6359622),
             LatLng(45.4579205, -73.6352244),
             LatLng(45.4569567, -73.6363608),
@@ -681,7 +681,7 @@ object CampusRepo {
             LatLng(45.4580204, -73.6363491)
         )),
 
-        Building("F.C. Smith Building", "FC", 0,listOf(
+        Building("F.C. Smith Building", "FC", 11147332003,listOf(
             LatLng(45.4583380, -73.6391598),
             LatLng(45.4584294, -73.6394033),
             LatLng(45.4584223, -73.6394083),
@@ -714,7 +714,7 @@ object CampusRepo {
             LatLng(45.4584058, -73.6391055)
         )),
 
-        Building("Centre for Structural and Functional Genomics", "GE", 0,listOf(
+        Building("Centre for Structural and Functional Genomics", "GE", 545014554,listOf(
             LatLng(45.4571701, -73.6405654),
             LatLng(45.4571108, -73.6406112),
             LatLng(45.4569490, -73.6407411),
@@ -729,7 +729,7 @@ object CampusRepo {
 
         )),
 
-        Building("Wing HA", "HA", 0,listOf(
+        Building("Wing HA", "HA", 47331994,listOf(
             LatLng(45.4592642, -73.6410461),
             LatLng(45.4594645, -73.6408908),
             LatLng(45.4594695, -73.6409038),
@@ -752,7 +752,7 @@ object CampusRepo {
             LatLng(45.4592718, -73.6410658)
         )),
 
-        Building("Wing HB", "HB", 0,listOf(
+        Building("Wing HB", "HB", 47331999,listOf(
             LatLng(45.4589611, -73.6418023),
             LatLng(45.4591597, -73.6416472),
             LatLng(45.4591648, -73.6416603),
@@ -781,7 +781,7 @@ object CampusRepo {
             LatLng(45.4589679, -73.6418198)
         )),
 
-        Building("Wing HC", "HC", 0,listOf(
+        Building("Wing HC", "HC", 604324438,listOf(
             LatLng(45.4598870, -73.6420067),
             LatLng(45.4597763, -73.6420908),
             LatLng(45.4597900, -73.6421262),
@@ -794,7 +794,7 @@ object CampusRepo {
             LatLng(45.4598200, -73.6418276)
         )),
 
-        Building("Applied Science Hub", "HU", 0,listOf(
+        Building("Applied Science Hub", "HU", 795012497,listOf(
             LatLng(45.4584315, -73.6421084),
             LatLng(45.4583945, -73.6420113),
             LatLng(45.4582761, -73.6416998),
@@ -810,26 +810,26 @@ object CampusRepo {
             LatLng(45.4587241, -73.6418822)
         )),
 
-        Building("Jesuit Residence", "JR", 0,listOf(
-            LatLng(45.4585404, -73.6433119),
-            LatLng(45.4584695, -73.6433673),
-            LatLng(45.4584643, -73.6433539),
-            LatLng(45.4583989, -73.6434051),
-            LatLng(45.4583699, -73.6433297),
-            LatLng(45.4583545, -73.6433417),
-            LatLng(45.4583155, -73.6432404),
-            LatLng(45.4583303, -73.6432288),
-            LatLng(45.4583021, -73.6431556),
-            LatLng(45.4583724, -73.6431006),
-            LatLng(45.4583787, -73.6431169),
-            LatLng(45.4584451, -73.6430649),
-            LatLng(45.4584738, -73.6431396),
-            LatLng(45.4584896, -73.6431273),
-            LatLng(45.4585280, -73.6432271),
-            LatLng(45.4585124, -73.6432393)
+        Building("Jesuit Residence", "JR", 129437733,listOf(
+            LatLng(45.4586419, -73.6433389),
+            LatLng(45.4585710, -73.6433943),
+            LatLng(45.4585658, -73.6433809),
+            LatLng(45.4585004, -73.6434321),
+            LatLng(45.4584714, -73.6433567),
+            LatLng(45.4584560, -73.6433687),
+            LatLng(45.4584170, -73.6432674),
+            LatLng(45.4584318, -73.6432558),
+            LatLng(45.4584036, -73.6431826),
+            LatLng(45.4584739, -73.6431276),
+            LatLng(45.4584802, -73.6431439),
+            LatLng(45.4585466, -73.6430919),
+            LatLng(45.4585753, -73.6431666),
+            LatLng(45.4585911, -73.6431543),
+            LatLng(45.4586295, -73.6432541),
+            LatLng(45.4586139, -73.6432663)
         )),
 
-        Building("PERFORM Centre", "PC", 0,listOf(
+        Building("PERFORM Centre", "PC", 604019520,listOf(
             LatLng(45.4572701, -73.6376525),
             LatLng(45.4570453, -73.6378295),
             LatLng(45.4570004, -73.6378624),
@@ -837,7 +837,7 @@ object CampusRepo {
             LatLng(45.4569334, -73.6367839)
         )),
 
-        Building("Physical Services Building", "PS", 0,listOf(
+        Building("Physical Services Building", "PS", 47332006,listOf(
             LatLng(45.4593968, -73.6395352),
             LatLng(45.4594378, -73.6396447),
             LatLng(45.4594167, -73.6396618),
@@ -852,7 +852,7 @@ object CampusRepo {
             LatLng(45.4593346, -73.6395831)
         )),
 
-        Building("Oscar Peterson Concert Hall", "PT", 0,listOf(
+        Building("Oscar Peterson Concert Hall", "PT", 604324443,listOf(
             LatLng(45.4595066, -73.6391376),
             LatLng(45.4593050, -73.6386725),
             LatLng(45.4591639, -73.6387860),
@@ -863,7 +863,7 @@ object CampusRepo {
             LatLng(45.4593607, -73.6392369)
         )),
 
-        Building("PY Building", "PY", 0,listOf(
+        Building("PY Building", "PY", 604324454,listOf(
             LatLng(45.4587698, -73.6407406),
             LatLng(45.4587966, -73.6408103),
             LatLng(45.4591103, -73.6405649),
@@ -878,7 +878,7 @@ object CampusRepo {
             LatLng(45.4587519, -73.6406940)
         )),
 
-        Building("RA Complex", "RA", 0,listOf(
+        Building("RA Complex", "RA", 47332005,listOf(
             LatLng(45.4566649, -73.6369952),
             LatLng(45.4563928, -73.6373369),
             LatLng(45.4563979, -73.6373525),
@@ -897,7 +897,7 @@ object CampusRepo {
             LatLng(45.4570004, -73.6378624)
         )),
 
-        Building("Loyola Jesuit Hall and Conference Center", "RF", 0,listOf(
+        Building("Loyola Jesuit Hall and Conference Center", "RF", 604324455,listOf(
             LatLng(45.4583412, -73.6409057),
             LatLng(45.4583493, -73.6408995),
             LatLng(45.4583941, -73.6410120),
@@ -919,7 +919,7 @@ object CampusRepo {
             LatLng(45.4583267, -73.6408679)
         )),
 
-        Building("Student Centre", "SC", 0,listOf(
+        Building("Student Centre", "SC", 47332009,listOf(
             LatLng(45.4592282, -73.6389487),
             LatLng(45.4591458, -73.6390148),
             LatLng(45.4591282, -73.6389701),
@@ -936,14 +936,14 @@ object CampusRepo {
             LatLng(45.4593362, -73.6392039)
         )),
 
-        Building("SH Building", "SH", 0,listOf(
+        Building("SH Building", "SH", 352622186,listOf(
             LatLng(45.4593132, -73.6426242),
             LatLng(45.4592216, -73.6426235),
             LatLng(45.4592224, -73.6424318),
             LatLng(45.4593140, -73.6424325)
         )),
 
-        Building("SI Building", "SI", 0,listOf(
+        Building("SI Building", "SI", 47331997,listOf(
             LatLng(45.4575836, -73.6423818),
             LatLng(45.4576174, -73.6424713),
             LatLng(45.4576488, -73.6425544),
@@ -979,7 +979,7 @@ object CampusRepo {
             LatLng(45.4576537, -73.6423280)
         )),
 
-        Building("Science Complex", "SP", 0,listOf(
+        Building("Science Complex", "SP", 47331993,listOf(
             LatLng(45.4569746, -73.6408295),
             LatLng(45.4570166, -73.6409402),
             LatLng(45.4569934, -73.6409581),
@@ -1031,14 +1031,14 @@ object CampusRepo {
             LatLng(45.4571441, -73.6406987)
         )),
 
-        Building("Terrebonne Building", "TA", 0,listOf(
+        Building("Terrebonne Building", "TA", 352622559,listOf(
             LatLng(45.4600516, -73.6408948),
             LatLng(45.4600117, -73.6407974),
             LatLng(45.4599197, -73.6408738),
             LatLng(45.4599596, -73.6409712)
         )),
 
-        Building("Vanier Library", "VL", 0,listOf(
+        Building("Vanier Library", "VL", 1449641781,listOf(
             LatLng(45.4590303, -73.6388426),
             LatLng(45.4588199, -73.6382949),
             LatLng(45.4589349, -73.6381995),
@@ -1051,7 +1051,7 @@ object CampusRepo {
             LatLng(45.4592771, -73.6386559)
         )) ,
 
-        Building("Vanier Extension", "VE", 0,listOf(
+        Building("Vanier Extension", "VE", 604324441,listOf(
             LatLng(45.4588274, -73.6390010),
             LatLng(45.4586120, -73.6384402),
             LatLng(45.4588149, -73.6382819),


### PR DESCRIPTION
- Adding OpenStreetMap way IDs to building data for traceability
- Fixing building polygon offset issues caused by differences between OSM geometry and Google Maps rendering