### PR TITLE
feat: implement outdoor directions UI and location-based routing selection

### DIFF
--- a/app/src/main/java/com/example/myapplication/MapsActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MapsActivity.kt
@@ -14,17 +14,29 @@ import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
+import android.content.Intent
+import com.example.myapplication.ui.components.DirectionsInfoPopup
+import android.net.Uri
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import com.google.android.libraries.places.api.Places
+import com.google.android.libraries.places.api.net.PlacesClient
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.core.content.ContextCompat
 import com.example.myapplication.data.CampusRepo
+import com.example.myapplication.logic.SearchResult
 import com.example.myapplication.logic.TrueLocationProvider
 import com.example.myapplication.map.TrueCameraController
 import com.example.myapplication.ui.components.CampusMap
 import com.example.myapplication.ui.components.CampusToggle
+import com.example.myapplication.ui.components.DirectionsHeader
+import com.example.myapplication.ui.models.MapUIMode
 import com.example.myapplication.ui.theme.ConcordiaMaroon
 import com.example.myapplication.ui.viewmodel.MapViewModel
 import com.google.android.gms.location.FusedLocationProviderClient
@@ -44,15 +56,18 @@ class MapsActivity : ComponentActivity() {
 
         val fusedLocationClient = LocationServices.getFusedLocationProviderClient(this)
         val locationProvider = TrueLocationProvider(fusedLocationClient)
+        val routeProvider = com.example.myapplication.logic.GoogleRouteProvider(BuildConfig.MAPS_API_KEY)
 
-        val masterViewModel = MapViewModel(locationProvider)
+        val viewModel = MapViewModel(locationProvider, routeProvider)
+
+        val placesClient = com.google.android.libraries.places.api.Places.createClient(this)
+        viewModel.initSearch(placesClient)
 
         setContent {
+            val mapPaddingBottom = if (viewModel.uiBuildingState.mode == MapUIMode.DIRECTIONS) 600 else 0
             val context = LocalContext.current
             val scope = rememberCoroutineScope()
             var showSettingsDialog by remember { mutableStateOf(false) }
-
-            val viewModel = masterViewModel
 
             var hasLocationPermission by remember {
                 mutableStateOf(ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED)
@@ -84,6 +99,7 @@ class MapsActivity : ComponentActivity() {
                 }
             }
 
+
             val cameraPositionState = rememberCameraPositionState {
                 position = CameraPosition.fromLatLngZoom(LatLng(45.497, -73.579), 16f)
             }
@@ -92,6 +108,17 @@ class MapsActivity : ComponentActivity() {
                 TrueCameraController(cameraPositionState)
             }
 
+
+            LaunchedEffect(viewModel.uiBuildingState.routeBounds) {
+                val bounds = viewModel.uiBuildingState.routeBounds
+                if (bounds != null) {
+                    kotlinx.coroutines.delay(500)
+                    cameraPositionState.animate(
+                        update = com.google.android.gms.maps.CameraUpdateFactory.newLatLngBounds(bounds, 400),
+                        durationMs = 1000
+                    )
+                }
+            }
             LaunchedEffect(viewModel.currentCampus) {
                 viewModel.currentCampus?.let { campus ->
                     cameraController.animateTo(campus.getGoogleCenter(), campus.defaultZoom)
@@ -102,6 +129,16 @@ class MapsActivity : ComponentActivity() {
                 hasLocationPermission = isGranted
             }
 
+            LaunchedEffect(viewModel.uiBuildingState.routeBounds) {
+                val bounds = viewModel.uiBuildingState.routeBounds
+                if (bounds != null) {
+                    kotlinx.coroutines.delay(500)
+                    cameraPositionState.animate(
+                        update = com.google.android.gms.maps.CameraUpdateFactory.newLatLngBounds(bounds, 150),
+                        durationMs = 1000
+                    )
+                }
+            }
             Box(modifier = Modifier.fillMaxSize()) {
                 CampusMap(
                     currentCampus = viewModel.currentCampus,
@@ -109,8 +146,82 @@ class MapsActivity : ComponentActivity() {
                     cameraPositionState = cameraPositionState,
                     hasLocationPermission = hasLocationPermission,
                     viewModel = viewModel,
+                    contentPadding = PaddingValues(bottom = mapPaddingBottom.dp),
                     modifier = Modifier.testTag("campus_map")
                 )
+
+                if (viewModel.uiBuildingState.mode == MapUIMode.PREVIEW) {
+                    com.example.myapplication.ui.components.CampusSearchBar(
+                        query = viewModel.searchQuery,
+                        results = viewModel.searchResults,
+                        onQueryChange = { viewModel.onSearchQueryChanged(it) },
+                        onResultClick = { viewModel.handleSearchResult(it, context) },
+                        modifier = Modifier
+                            .align(Alignment.TopCenter)
+                            .padding(top = 8.dp)
+                    )
+                } else {
+                    if (viewModel.uiBuildingState.isSearchExpanded) {
+                        DirectionsHeader(
+                            uiState = viewModel.uiBuildingState,
+                            onBackClick = { viewModel.toggleSearchExpansion(false) },
+                            onStartQueryChange = { viewModel.onSearchQueryChanged(it, field = "start") },
+                            onDestQueryChange = { viewModel.onSearchQueryChanged(it, field = "dest") },
+                            modifier = Modifier.align(Alignment.TopCenter)
+                        )
+                    }
+
+                    if (viewModel.uiBuildingState.mode == MapUIMode.DIRECTIONS) {
+                        DirectionsInfoPopup(
+                            uiState = viewModel.uiBuildingState,
+                            onModeChange = { viewModel.onTransportModeChanged(it) },
+                            onStartClick = { viewModel.toggleSearchExpansion(true, "start") },
+                            onDestinationClick = { viewModel.toggleSearchExpansion(true, "dest") },
+                            onSwapClick = { viewModel.swapLocations() },
+                            onClose = { viewModel.onBackToPreview() },
+                            onStartNavigation = { /* ... */ },
+                            modifier = Modifier.align(Alignment.BottomCenter)
+                        )
+                    }
+
+                    val currentFieldText = when(viewModel.activeSearchField) {
+                        "start" -> viewModel.uiBuildingState.startLocationName
+                        "dest" -> viewModel.uiBuildingState.destinationName
+                        else -> viewModel.searchQuery
+                    }
+
+                    if (viewModel.activeSearchField != "main" && currentFieldText.isNotEmpty()) {
+                        Card(
+                            modifier = Modifier
+                                .padding(horizontal = 24.dp)
+                                .offset(y = 190.dp) // Adjusted slightly to sit below the DirectionsHeader
+                                .zIndex(1f), // Ensure it sits on top of everything
+                            elevation = CardDefaults.cardElevation(4.dp),
+                            colors = CardDefaults.cardColors(containerColor = Color.White)
+                        ) {
+                            LazyColumn(modifier = Modifier.fillMaxWidth().heightIn(max = 300.dp)) {
+                                items(viewModel.searchResults) { result ->
+                                    val title = when(result) {
+                                        is com.example.myapplication.logic.SearchResult.BuildingResult -> result.building.name
+                                        is SearchResult.CampusResult -> result.campus.name
+                                        is com.example.myapplication.logic.SearchResult.GoogleResult -> result.title
+                                        is com.example.myapplication.logic.SearchResult.CurrentLocation -> "Your position"
+                                        is com.example.myapplication.logic.SearchResult.Home -> "Home"
+                                    }
+
+                                    ListItem(
+                                        headlineContent = { Text(title) },
+                                        modifier = Modifier.clickable {
+                                            viewModel.handleSearchResult(result, context)
+                                        }
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                }
+
 
                 if (showSettingsDialog && !hasLocationPermission) {
                     AlertDialog(
@@ -142,15 +253,7 @@ class MapsActivity : ComponentActivity() {
                     )
                 }
 
-                if (viewModel.uiBuildingState.isVisible) {
-                    viewModel.uiBuildingState.building?.let { building ->
-                        com.example.myapplication.ui.components.BuildingInfoPopup(
-                            building = building,
-                            uiState = viewModel.uiBuildingState,
-                            onDismiss = { viewModel.handleMapTap(null) } // Reset state to hide it
-                        )
-                    }
-                }
+                if (viewModel.uiBuildingState.mode != MapUIMode.DIRECTIONS) {
                 CampusToggle(
                     selectedCampusName = viewModel.currentCampus?.name,
                     onCampusClick = { name ->
@@ -182,14 +285,31 @@ class MapsActivity : ComponentActivity() {
                     icon = { Icon(Icons.Default.MyLocation, contentDescription = null) },
                     text = { Text(text = "RECENTER") }
                 )
+                }
 
                 if (viewModel.uiBuildingState.isVisible) {
                     viewModel.uiBuildingState.building?.let { building ->
-                        BuildingInfoPopup(
-                            building = building,
-                            uiState = viewModel.uiBuildingState,
-                            onDismiss = { viewModel.handleMapTap(null) }
-                        )
+                        if (viewModel.uiBuildingState.mode == com.example.myapplication.ui.models.MapUIMode.PREVIEW) {
+                            BuildingInfoPopup(
+                                building = building,
+                                uiState = viewModel.uiBuildingState,
+                                onDismiss = { viewModel.handleMapTap(null) },
+                                onDirectionsClick = { viewModel.onDirectionsRequested() }
+                            )
+                        }
+                        else {
+                            DirectionsInfoPopup(
+                                uiState = viewModel.uiBuildingState,
+                                onModeChange = { mode -> viewModel.onTransportModeChanged(mode) },
+                                onStartClick = { viewModel.toggleSearchExpansion(true, "start") },
+                                onDestinationClick = { viewModel.toggleSearchExpansion(true, "dest") },
+                                onSwapClick = { viewModel.swapLocations() },
+                                onClose = { viewModel.onBackToPreview() },
+                                onStartNavigation = { /* Logic for navigation later */ },
+                                modifier = Modifier.align(Alignment.BottomCenter)
+                            )
+                        }
+
                     }
                 }
             }

--- a/app/src/main/java/com/example/myapplication/data/CampusData.kt
+++ b/app/src/main/java/com/example/myapplication/data/CampusData.kt
@@ -10,6 +10,7 @@ data class Building(
     val name: String,
     val code: String,
     val wayID: Long,
+    val fullAddress: String = "Concordia University",
     val outline: List<JsonLatLng>?, // Make nullable for safety
     val isCampusBuilding: Boolean = true
 ) {
@@ -130,4 +131,5 @@ object CampusRepo {
         val xIntersection = (pY - bee) / m
         return xIntersection > pX
     }
+    fun getAllCampuses(): List<Campus> = allCampuses
 }

--- a/app/src/main/java/com/example/myapplication/logic/GoogleRouteProvider.kt
+++ b/app/src/main/java/com/example/myapplication/logic/GoogleRouteProvider.kt
@@ -1,0 +1,64 @@
+package com.example.myapplication.logic
+
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.PolyUtil
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class GoogleRouteProvider(private val apiKey: String) : RouteProvider {
+    private val client = OkHttpClient()
+
+    override suspend fun getRoute(start: LatLng, end: LatLng, mode: String): RouteData? = withContext(Dispatchers.IO) {
+        val transportMode = when(mode) {
+            "transit" -> "transit"
+            "drive" -> "driving"
+            else -> "walking"
+        }
+
+        val url = "https://maps.googleapis.com/maps/api/directions/json?" +
+                "origin=${start.latitude},${start.longitude}" +
+                "&destination=${end.latitude},${end.longitude}" +
+                "&mode=$transportMode" +
+                "&key=$apiKey"
+
+        try {
+            val request = Request.Builder().url(url).build()
+            val response = client.newCall(request).execute()
+            val responseBody = response.body?.string() ?: ""
+
+            android.util.Log.d("ROUTE_DEBUG", "Response: $responseBody")
+
+            val json = JSONObject(responseBody)
+
+            if (json.getString("status") != "OK") {
+                android.util.Log.e("ROUTE_DEBUG", "Error Status: ${json.getString("status")}")
+                // Return null instead of a list to match the RouteData? type
+                return@withContext null
+            }
+
+            val routes = json.getJSONArray("routes")
+
+            if (routes.length() > 0) {
+                val route = routes.getJSONObject(0)
+                val leg = route.getJSONArray("legs").getJSONObject(0)
+
+                val durationText = leg.getJSONObject("duration").getString("text")
+                val distanceText = leg.getJSONObject("distance").getString("text")
+
+                val overviewPolyline = route.getJSONObject("overview_polyline").getString("points")
+                val decodedPoints = PolyUtil.decode(overviewPolyline)
+
+                // Return the custom object
+                return@withContext RouteData(decodedPoints, durationText, distanceText)
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("ROUTE_DEBUG", "Exception: ${e.message}")
+        }
+
+        // Final fallback: return null if everything fails
+        return@withContext null
+    }
+}

--- a/app/src/main/java/com/example/myapplication/logic/MapInteractionHandler.kt
+++ b/app/src/main/java/com/example/myapplication/logic/MapInteractionHandler.kt
@@ -6,6 +6,7 @@ import com.google.android.gms.maps.model.LatLng
 import com.example.myapplication.ui.viewmodel.MapViewModel
 import java.util.Locale
 import com.example.myapplication.BuildConfig
+import com.example.myapplication.data.Building
 
 object MapInteractionHandler {
     fun processClick(latLng: LatLng, viewModel: MapViewModel, context: Context) {
@@ -55,5 +56,18 @@ object MapInteractionHandler {
             "Address unavailable"
         }
     }
+
+    fun handleSearchSelection(building: Building, viewModel: MapViewModel, context: Context) {
+        val center = building.getCenter()
+
+        val realStreetAddress = getAddressFromCoords(context, center)
+
+        viewModel.handleMapTap(building, realStreetAddress, null)
+
+        fetchProfessionalData(context, center) { photoUrl ->
+            viewModel.handleMapTap(building, realStreetAddress, photoUrl)
+        }
+    }
+
 }
 

--- a/app/src/main/java/com/example/myapplication/logic/RouteProvider.kt
+++ b/app/src/main/java/com/example/myapplication/logic/RouteProvider.kt
@@ -1,108 +1,32 @@
 package com.example.myapplication.logic
 
-import android.content.Context
-import android.content.pm.PackageManager
 import com.google.android.gms.maps.model.LatLng
-import com.google.maps.android.PolyUtil
-import java.io.IOException
-import okhttp3.*
-import org.json.JSONObject
+
+data class RouteData(
+    val points: List<LatLng>,
+    val duration: String,
+    val distance: String
+)
 
 interface RouteProvider {
-    fun getRoute(start: LatLng,
-                 end: LatLng,
-                 travelMode: TravelMode,
-                 callback: (Result<List<LatLng>>) -> Unit
-    )
+    suspend fun getRoute(
+        start: LatLng,
+        end: LatLng,
+        mode: String
+    ): RouteData?
 }
 
-class GoogleRouteProvider(private val context: Context,
-                          private val client: OkHttpClient = OkHttpClient()) : RouteProvider {
-
-    // Send to callback function a path between two points using the google routes api.
-    override fun getRoute(start: LatLng,
-                          end: LatLng,
-                          travelMode: TravelMode,
-                          callback: (Result<List<LatLng>>) -> Unit
-    ) {
-        val mode = when (travelMode) {
-            TravelMode.PUB_TRANSIT -> "transit"
-            TravelMode.MOTORIZED -> "driving"
-            TravelMode.WALK -> "walking"
-        }
-
-        val appInfo = context.packageManager.getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)
-        val apiKey = appInfo.metaData.getString("com.google.android.geo.API_KEY")
-
-        val url = "https://maps.googleapis.com/maps/api/directions/json?" +
-                "origin=${start.latitude},${start.longitude}" +
-                "&destination=${end.latitude},${end.longitude}" +
-                "&mode=$mode" +
-                "&key=${apiKey}"
-
-        val request = Request.Builder().url(url).build()
-
-        client.newCall(request).enqueue(object : Callback {
-            override fun onFailure(call: Call, e: IOException) {
-                callback(Result.failure(e))
-            }
-
-            override fun onResponse(call: Call, response: Response) {
-                response.body.string().let { json ->
-                    val points = decodeRoute(json)
-                    callback(Result.success(points))
-                }
-            }
-        })
-    }
+class SimpleMockRouteProvider(private val mockData: RouteData? = null) : RouteProvider {
+    override suspend fun getRoute(start: LatLng, end: LatLng, mode: String): RouteData? = mockData
 }
 
-// Returns parsed path given a valid json string and exception otherwise.
-fun decodeRoute(json: String): List<LatLng> {
-    val points = mutableListOf<LatLng>()
-    try {
-        val jsonObject = JSONObject(json)
-        val routes = jsonObject.getJSONArray("routes")
-        if (routes.length() > 0) {
-            val lineBytes = routes.getJSONObject(0)
-                .getJSONObject("overview_polyline")
-                .getString("points")
-            // Google api returns string of characters representing bytes
-            // describing the points in a sequence. These need to be parsed
-            // with a known algorithm before usable.
-            points.addAll(PolyUtil.decode(lineBytes))
-        }
-    } catch (e: Exception) {
-        e.printStackTrace()
-    }
-    return points
-}
-
-class SimpleMockRouteProvider(private val points: List<LatLng> = emptyList()) : RouteProvider {
-
-    override fun getRoute(start: LatLng,
-                          end: LatLng,
-                          travelMode: TravelMode,
-                          callback: (Result<List<LatLng>>) -> Unit
-    ) {
-        callback(Result.success(points))
-    }
-}
-
-class InterpolatingMockRouteProvider(
-    private var steps: UInt
-) : RouteProvider {
-
-    override fun getRoute(start: LatLng,
-                          end: LatLng,
-                          travelMode: TravelMode,
-                          callback: (Result<List<LatLng>>) -> Unit
-    ) {
+class InterpolatingMockRouteProvider(private var steps: UInt) : RouteProvider {
+    override suspend fun getRoute(start: LatLng, end: LatLng, mode: String): RouteData? {
         val latStep = (end.latitude - start.latitude) / steps.toDouble()
         val lngStep = (end.longitude - start.longitude) / steps.toDouble()
         val points = (0..steps.toInt()).map { i ->
             LatLng(start.latitude + latStep * i, start.longitude + lngStep * i)
         }
-        callback(Result.success(points))
+        return RouteData(points, "0 mins", "0 km")
     }
 }

--- a/app/src/main/java/com/example/myapplication/logic/SearchProvider.kt
+++ b/app/src/main/java/com/example/myapplication/logic/SearchProvider.kt
@@ -1,0 +1,47 @@
+package com.example.myapplication.logic
+
+import com.example.myapplication.data.Building
+import com.example.myapplication.data.Campus
+import com.example.myapplication.data.CampusRepo
+import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest
+import com.google.android.libraries.places.api.net.PlacesClient
+import kotlinx.coroutines.tasks.await
+
+sealed class SearchResult {
+    data class BuildingResult(val building: Building) : SearchResult()
+    data class CampusResult(val campus: Campus) : SearchResult()
+    data class GoogleResult(val title: String, val address: String, val placeId: String) : SearchResult()
+    object CurrentLocation : SearchResult()
+    object Home : SearchResult()
+}
+
+class HybridSearchProvider(private val placesClient: PlacesClient) {
+    suspend fun search(query: String): List<SearchResult> {
+        if (query.isBlank()) return listOf(SearchResult.CurrentLocation, SearchResult.Home)
+
+        val campusMatches = CampusRepo.getAllCampuses().filter { campus ->
+            campus.name.contains(query, ignoreCase = true)
+        }.map { SearchResult.CampusResult(it) }
+
+        val allBuildings = CampusRepo.getAllCampuses().flatMap { it.buildings }
+        val localMatches = allBuildings.filter { building ->
+            building.name.contains(query, ignoreCase = true) ||
+                    building.code.contains(query, ignoreCase = true)
+        }.take(3).map { SearchResult.BuildingResult(it) }
+
+        val request = FindAutocompletePredictionsRequest.builder().setQuery(query).build()
+        return try {
+            val response = placesClient.findAutocompletePredictions(request).await()
+            val googleMatches = response.autocompletePredictions.map { prediction ->
+                SearchResult.GoogleResult(
+                    title = prediction.getPrimaryText(null).toString(),
+                    address = prediction.getSecondaryText(null).toString(),
+                    placeId = prediction.placeId
+                )
+            }
+            campusMatches + localMatches + googleMatches
+        } catch (e: Exception) {
+            campusMatches + localMatches
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapplication/ui/components/BuildingInfoPopup.kt
+++ b/app/src/main/java/com/example/myapplication/ui/components/BuildingInfoPopup.kt
@@ -3,10 +3,7 @@ package com.example.myapplication.ui.components
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Directions
-import androidx.compose.material.icons.filled.PinDrop
-import androidx.compose.material.icons.filled.Save
-import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -15,7 +12,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.example.myapplication.data.Building
 import com.example.myapplication.ui.models.BuildingUiState
-import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import coil.compose.AsyncImage
@@ -24,7 +20,8 @@ import coil.compose.AsyncImage
 fun BuildingInfoPopup(
     building: Building,
     uiState: BuildingUiState,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    onDirectionsClick: () -> Unit // Added this
 ) {
     Box(
         modifier = Modifier.fillMaxSize(),
@@ -37,7 +34,6 @@ fun BuildingInfoPopup(
             elevation = CardDefaults.cardElevation(12.dp)
         ) {
             Column {
-                // THE IMAGE
                 AsyncImage(
                     model = uiState.imageUrl ?: "https://your-placeholder-url.com/campus.jpg",
                     contentDescription = null,
@@ -52,17 +48,14 @@ fun BuildingInfoPopup(
                         modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
                         horizontalArrangement = Arrangement.SpaceEvenly
                     ) {
-                        ActionButton(Icons.Default.Directions, "Directions")
-                        ActionButton(Icons.Default.Save, "Save")
-                        ActionButton(Icons.Default.PinDrop, "PIN")
-                        ActionButton(Icons.Default.Share, "Share")
+                        // Wired the click here
+                        ActionButton(Icons.Default.Directions, "Directions", onDirectionsClick)
+                        ActionButton(Icons.Default.Save, "Save") {}
+                        ActionButton(Icons.Default.PinDrop, "PIN") {}
+                        ActionButton(Icons.Default.Share, "Share") {}
                     }
 
-                    HorizontalDivider(
-                        modifier = Modifier.padding(vertical = 8.dp),
-                        thickness = 1.dp,
-                        color = Color.LightGray
-                    )
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), thickness = 1.dp, color = Color.LightGray)
                     Row(modifier = Modifier.padding(top = 16.dp), verticalAlignment = Alignment.CenterVertically) {
                         Icon(Icons.Default.LocationOn, contentDescription = null, tint = Color.Blue)
                         Spacer(Modifier.width(8.dp))
@@ -75,12 +68,11 @@ fun BuildingInfoPopup(
 }
 
 @Composable
-fun ActionButton(icon: ImageVector, label: String) {
+fun ActionButton(icon: ImageVector, label: String, onClick: () -> Unit) {
     val concordiaBlue = Color(0xFF1652f0)
-
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         FilledTonalIconButton(
-            onClick = { /* TODO */ },
+            onClick = onClick,
             colors = IconButtonDefaults.filledTonalIconButtonColors(
                 containerColor = concordiaBlue.copy(alpha = 0.1f),
                 contentColor = concordiaBlue

--- a/app/src/main/java/com/example/myapplication/ui/components/CampusMap.kt
+++ b/app/src/main/java/com/example/myapplication/ui/components/CampusMap.kt
@@ -11,6 +11,10 @@ import com.example.myapplication.ui.theme.concordiaGold
 import com.example.myapplication.ui.viewmodel.MapViewModel
 import com.google.maps.android.compose.*
 import com.example.myapplication.logic.MapInteractionHandler
+import com.example.myapplication.ui.theme.ConcordiaGreen
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun CampusMap(
@@ -19,13 +23,15 @@ fun CampusMap(
     cameraPositionState: CameraPositionState,
     hasLocationPermission: Boolean,
     modifier: Modifier = Modifier,
-    viewModel: MapViewModel
+    viewModel: MapViewModel,
+    contentPadding: PaddingValues = PaddingValues(0.dp)
 ) {
     val context = LocalContext.current
 
     GoogleMap(
         modifier = Modifier.fillMaxSize().testTag("google_map"),
         cameraPositionState = cameraPositionState,
+        contentPadding = contentPadding,
         properties = MapProperties(isMyLocationEnabled = hasLocationPermission),
         uiSettings = MapUiSettings(
             myLocationButtonEnabled = false,
@@ -33,26 +39,71 @@ fun CampusMap(
         ),
         onMapClick = { latLng -> MapInteractionHandler.processClick(latLng, viewModel, context )}
     ) {
-        currentCampus?.buildings?.forEach { building ->
-            val points = building.getGoogleOutline()
-            val isHighlighted = building.name == highlightedBuildingName
-            val isSelected = viewModel.uiBuildingState.building?.name == building.name
+        // 1. THE ROUTE LINE
+        if (viewModel.uiBuildingState.routePoints.isNotEmpty()) {
+            val transportMode = viewModel.uiBuildingState.selectedTransportMode
+            Polyline(
+                points = viewModel.uiBuildingState.routePoints,
+                color = com.example.myapplication.ui.theme.ConcordiaBlue,
+                width = 12f,
+                jointType = com.google.android.gms.maps.model.JointType.ROUND,
+                pattern = if (transportMode == "walk") {
+                    listOf(com.google.android.gms.maps.model.Dash(20f), com.google.android.gms.maps.model.Gap(20f))
+                } else null
+            )
+        }
 
-            if (points.isNotEmpty()) {
-                Polygon(
-                    points = points,
+        // 2. THE BUILDING POLYGONS (Draw all campuses)
+        com.example.myapplication.data.CampusRepo.getAllCampuses().forEach { campus ->
+            campus.buildings.forEach { building ->
+                val points = building.getGoogleOutline()
 
-                    fillColor = when{
-                        isSelected -> com.example.myapplication.ui.theme.ConcordiaBlue.copy(alpha = 0.5f)
-                        isHighlighted -> concordiaGold.copy(alpha = 0.5f)
-                        else -> ConcordiaMaroon.copy(alpha = 0.3f)
-                    },
-                    strokeColor = when {
-                        isSelected -> com.example.myapplication.ui.theme.ConcordiaBlue
-                        isHighlighted -> concordiaGold
-                        else -> ConcordiaMaroon
-                    },
-                    strokeWidth = if (isSelected || isHighlighted) 10f else 5f
+                // Highlight logic
+                val isDestinationBuilding = viewModel.uiBuildingState.mode == com.example.myapplication.ui.models.MapUIMode.DIRECTIONS
+                        && building.name == viewModel.uiBuildingState.destinationName
+
+                val isSelected = viewModel.uiBuildingState.building?.name == building.name
+                val isHighlighted = building.name == highlightedBuildingName
+
+                if (points.isNotEmpty()) {
+                    Polygon(
+                        points = points,
+                        fillColor = when {
+                            isDestinationBuilding -> ConcordiaGreen.copy(alpha = 0.3f)
+                            isSelected -> com.example.myapplication.ui.theme.ConcordiaBlue.copy(alpha = 0.5f)
+                            isHighlighted -> concordiaGold.copy(alpha = 0.5f)
+                            else -> ConcordiaMaroon.copy(alpha = 0.3f)
+                        },
+                        strokeColor = when {
+                            isDestinationBuilding -> ConcordiaGreen.copy(alpha = 0.5f)
+                            isSelected -> com.example.myapplication.ui.theme.ConcordiaBlue
+                            isHighlighted -> concordiaGold
+                            else -> ConcordiaMaroon
+                        },
+                        strokeWidth = if (isSelected || isHighlighted || isDestinationBuilding) 10f else 5f
+                    )
+                }
+            }
+        }
+
+        // 3. THE NAVIGATION MARKERS (Outside the loop so they follow coordinates, not building objects)
+        if (viewModel.uiBuildingState.mode == com.example.myapplication.ui.models.MapUIMode.DIRECTIONS) {
+
+            // START POINT (The Big Azure Dot)
+            viewModel.uiBuildingState.startPoint?.let { startPos ->
+                Marker(
+                    state = MarkerState(position = startPos),
+                    title = "Start: ${viewModel.uiBuildingState.startLocationName}",
+                    icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE)
+                )
+            }
+
+            // END POINT (The Red Destination Marker)
+            viewModel.uiBuildingState.endPoint?.let { endPos ->
+                Marker(
+                    state = MarkerState(position = endPos),
+                    title = "Destination: ${viewModel.uiBuildingState.destinationName}",
+                    icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_RED)
                 )
             }
         }

--- a/app/src/main/java/com/example/myapplication/ui/components/CampusSearchBar.kt
+++ b/app/src/main/java/com/example/myapplication/ui/components/CampusSearchBar.kt
@@ -1,0 +1,82 @@
+package com.example.myapplication.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Business
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.example.myapplication.logic.SearchResult
+import androidx.compose.material.icons.filled.Home
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CampusSearchBar(
+    query: String,
+    results: List<SearchResult>,
+    onQueryChange: (String) -> Unit,
+    onResultClick: (SearchResult) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var active by remember { mutableStateOf(false) }
+
+    SearchBar(
+        query = query,
+        onQueryChange = onQueryChange,
+        onSearch = { active = false },
+        active = active,
+        onActiveChange = { active = it },
+        placeholder = { Text("Search buildings or addresses...") },
+        leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+        modifier = modifier.fillMaxWidth().padding(16.dp),
+        colors = SearchBarDefaults.colors(containerColor = Color.White)
+    ) {
+        LazyColumn(modifier = Modifier.fillMaxWidth()) {
+            items(results) { result ->
+                val title = when(result) {
+                    is SearchResult.BuildingResult -> result.building.name
+                    is SearchResult.CampusResult -> result.campus.name
+                    is SearchResult.GoogleResult -> result.title
+                    is SearchResult.CurrentLocation -> "Your position"
+                    is SearchResult.Home -> "Home"
+                }
+
+                val icon = when(result) {
+                    is SearchResult.BuildingResult -> Icons.Default.Business
+                    is SearchResult.CampusResult -> Icons.Default.LocationOn
+                    is SearchResult.GoogleResult -> Icons.Default.LocationOn
+                    is SearchResult.CurrentLocation -> Icons.Default.MyLocation
+                    is SearchResult.Home -> Icons.Default.Home
+                }
+
+                val tintColor = if (result is SearchResult.CurrentLocation || result is SearchResult.Home) {
+                    Color(0xFF4285F4) // Google Blue
+                } else {
+                    Color(0xFF912338) // Concordia Maroon
+                }
+
+                ListItem(
+                    headlineContent = { Text(title) },
+                    supportingContent = {
+                        if(result is SearchResult.GoogleResult) Text(result.address)
+                    },
+                    leadingContent = {
+                        Icon(icon, contentDescription = null, tint = tintColor)
+                    },
+                    modifier = Modifier.clickable {
+                        onResultClick(result)
+                        active = false
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapplication/ui/components/DirectionsHeader.kt
+++ b/app/src/main/java/com/example/myapplication/ui/components/DirectionsHeader.kt
@@ -1,0 +1,79 @@
+package com.example.myapplication.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.example.myapplication.ui.models.BuildingUiState
+
+@Composable
+fun DirectionsHeader(
+    uiState: BuildingUiState,
+    onBackClick: () -> Unit,
+    onStartQueryChange: (String) -> Unit,
+    onDestQueryChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        elevation = CardDefaults.cardElevation(8.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        shape = RoundedCornerShape(16.dp)
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                IconButton(onClick = onBackClick) { Icon(Icons.Default.ArrowBack, null) }
+                Text("Directions", style = MaterialTheme.typography.titleMedium)
+            }
+
+            // Start Field
+            SearchInput(
+                label = "Starting point",
+                value = uiState.startLocationName,
+                onValueChange = { onStartQueryChange(it) },
+                icon = Icons.Default.MyLocation,
+                iconColor = Color.Blue
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            // Destination Field
+            SearchInput(
+                label = "Destination",
+                value = uiState.destinationName,
+                onValueChange = { onDestQueryChange(it) },
+                icon = Icons.Default.LocationOn,
+                iconColor = Color.Red
+            )
+        }
+    }
+}
+@Composable
+private fun SearchInput(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    iconColor: Color
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+        label = { Text(label) },
+        leadingIcon = { Icon(icon, null, tint = iconColor) },
+        shape = RoundedCornerShape(8.dp),
+        singleLine = true,
+        colors = TextFieldDefaults.colors(focusedContainerColor = Color(0xFFF5F5F5))
+    )
+}

--- a/app/src/main/java/com/example/myapplication/ui/components/DirectionsInfoPopup.kt
+++ b/app/src/main/java/com/example/myapplication/ui/components/DirectionsInfoPopup.kt
@@ -1,0 +1,218 @@
+package com.example.myapplication.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.DirectionsWalk
+import androidx.compose.material.icons.filled.DirectionsBus
+import androidx.compose.material.icons.filled.DirectionsCar
+import androidx.compose.material.icons.filled.ImportExport
+import androidx.compose.material.icons.filled.DirectionsWalk
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.myapplication.ui.theme.ConcordiaMaroon
+import androidx.compose.foundation.clickable
+import androidx.compose.material.icons.filled.Circle
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextOverflow
+import com.example.myapplication.ui.models.BuildingUiState
+
+@Composable
+fun DirectionsInfoPopup(
+    uiState: BuildingUiState,
+    onModeChange: (String) -> Unit,
+    onStartClick: () -> Unit,
+    onSwapClick: () -> Unit,
+    onDestinationClick: () -> Unit,
+    onClose: () -> Unit,
+    onStartNavigation: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 20.dp)
+    ) {
+        // Main Semi-Translucent Container
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(28.dp),
+            color = Color.White.copy(alpha = 0.92f), // Translucent effect
+            shadowElevation = 10.dp
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                // Header with X
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text("Directions", style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold))
+                    IconButton(onClick = onClose) {
+                        Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.Black)
+                    }
+                }
+
+                // Transport Toggle Pill
+                TransportModeToggle(uiState.selectedTransportMode, onModeChange)
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Location Rows (Native Mockup Style)
+                LocationRow(
+                    label = uiState.startLocationName,
+                    icon = Icons.Default.Circle,
+                    iconColor = Color(0xFF4285F4),
+                    trailingIcon = Icons.Default.ImportExport, // Use swap icon
+                    onTrailingIconClick = onSwapClick, // Trigger the swap
+                    onClick = onStartClick
+                )
+
+                Divider(modifier = Modifier.padding(start = 40.dp), thickness = 0.5.dp, color = Color.LightGray)
+
+                LocationRow(
+                    label = uiState.destinationName,
+                    icon = Icons.Default.LocationOn,
+                    iconColor = Color(0xFFEA4335),
+                    trailingIcon = Icons.Default.Menu, // Keep menu icon for the second one
+                    onClick = onDestinationClick
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // NESTED ETA CARD (The Rounded Grey Rectangle from Mockup)
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(20.dp),
+                    color = Color(0xFFF1F3F4) // Light Google Grey
+                ) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = uiState.routeDuration,
+                                style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold)
+                            )
+                            Text(
+                                text = "Fastest route · ${uiState.routeDistance}",
+                                color = Color.Gray,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+
+                        // Action Button (Car Icon in Circle)
+                        Surface(
+                            shape = CircleShape,
+                            color = Color.White,
+                            modifier = Modifier.size(44.dp)
+                        ) {
+                            Icon(
+                                imageVector = when(uiState.selectedTransportMode) {
+                                    "drive" -> Icons.Default.DirectionsCar
+                                    "walk" -> Icons.AutoMirrored.Filled.DirectionsWalk
+                                    else -> Icons.Default.DirectionsBus
+                                },
+                                contentDescription = null,
+                                modifier = Modifier.padding(10.dp),
+                                tint = Color(0xFF5F6368)
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Button(
+                    onClick = onStartNavigation,
+                    modifier = Modifier.fillMaxWidth().height(54.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF912338)), // Concordia Maroon
+                    shape = RoundedCornerShape(16.dp)
+                ) {
+                    Text(
+                        text = if (uiState.startLocationName == "Your position") "START" else "PREVIEW",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = Color.White
+                    )                }
+            }
+        }
+    }
+}
+
+@Composable
+fun LocationRow(
+    label: String,
+    icon: ImageVector,
+    iconColor: Color,
+    trailingIcon: ImageVector = Icons.Default.Menu, // Default to menu
+    onTrailingIconClick: () -> Unit = {},           // Default to nothing
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(icon, contentDescription = null, tint = iconColor, modifier = Modifier.size(20.dp))
+        Spacer(modifier = Modifier.width(16.dp))
+        Text(text = label, style = MaterialTheme.typography.bodyLarge, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Spacer(modifier = Modifier.weight(1f))
+
+        IconButton(onClick = onTrailingIconClick) {
+            Icon(trailingIcon, contentDescription = null, tint = Color.LightGray, modifier = Modifier.size(22.dp))
+        }
+    }
+}
+@Composable
+fun TransportModeToggle(selectedMode: String, onModeChange: (String) -> Unit) {
+    Surface(
+        color = Color(0xFFF1F3F4),
+        shape = RoundedCornerShape(24.dp),
+        modifier = Modifier.padding(vertical = 8.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(4.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            val modes = listOf(
+                Triple("walk", Icons.AutoMirrored.Filled.DirectionsWalk, "Walk"),
+                Triple("drive", Icons.Default.DirectionsCar, "Drive"),
+                Triple("transit", Icons.Default.DirectionsBus, "Transit")
+            )
+
+            modes.forEach { (mode, icon, label) ->
+                val isSelected = selectedMode == mode
+                Surface(
+                    modifier = Modifier
+                        .height(40.dp)
+                        .weight(1f)
+                        .clickable { onModeChange(mode) },
+                    color = if (isSelected) Color(0xFF1A73E8) else Color.Transparent,
+                    shape = RoundedCornerShape(20.dp)
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            imageVector = icon,
+                            contentDescription = label,
+                            tint = if (isSelected) Color.White else Color(0xFF5F6368),
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapplication/ui/models/BuildingInfo.kt
+++ b/app/src/main/java/com/example/myapplication/ui/models/BuildingInfo.kt
@@ -2,9 +2,26 @@ package com.example.myapplication.ui.models
 
 import com.example.myapplication.data.Building
 
+enum class MapUIMode {
+    PREVIEW,    // Just looking at a building
+    DIRECTIONS  // Choosing start/end and travel mode
+}
+
 data class BuildingUiState(
     val isVisible: Boolean = false,
+    val mode: MapUIMode = MapUIMode.PREVIEW,
     val building: Building? = null,
     val fullAddress: String? = null,
-    val imageUrl: String? = null
+    val imageUrl: String? = null,
+    val startLocationName: String = "Your position", // Default start
+    val destinationName: String = "",
+    val startPoint: com.google.android.gms.maps.model.LatLng? = null,
+    val endPoint: com.google.android.gms.maps.model.LatLng? = null,
+    val routePoints: List<com.google.android.gms.maps.model.LatLng> = emptyList(),
+    val selectedTransportMode: String = "walk",
+    val isSearchExpanded: Boolean = false,
+    val isStartCurrentLocation: Boolean = false,
+    val routeBounds: com.google.android.gms.maps.model.LatLngBounds? = null,
+    val routeDuration: String = "-- min",
+    val routeDistance: String = "-- m",
 )

--- a/app/src/main/java/com/example/myapplication/ui/models/SearchUiState.kt
+++ b/app/src/main/java/com/example/myapplication/ui/models/SearchUiState.kt
@@ -1,0 +1,10 @@
+package com.example.myapplication.ui.models
+
+import com.example.myapplication.logic.SearchResult
+
+data class SearchUiState(
+    val query: String = "",
+    val results: List<SearchResult> = emptyList(),
+    val isSearching: Boolean = false,
+    val showSuggestions: Boolean = false
+)

--- a/app/src/main/java/com/example/myapplication/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/myapplication/ui/theme/Color.kt
@@ -18,3 +18,5 @@ val lightMaroon = ConcordiaMaroon.copy(alpha = 0.7f)
 val faintMaroon = ConcordiaMaroon.copy(alpha = 0.2f)
 val concordiaGold = Color(0xFFFFD700)
 val ConcordiaBlue = Color(0xFF1652f0)
+
+val ConcordiaGreen = Color(0xFF006638)

--- a/app/src/main/java/com/example/myapplication/ui/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/ui/viewmodel/MapViewModel.kt
@@ -7,18 +7,39 @@ import androidx.lifecycle.ViewModel
 import com.example.myapplication.data.Building
 import com.example.myapplication.data.Campus
 import com.example.myapplication.data.CampusRepo
-import com.example.myapplication.logic.LocationProvider // Added this
+import com.example.myapplication.logic.LocationProvider
+import androidx.lifecycle.viewModelScope
+import com.example.myapplication.BuildConfig
+import com.example.myapplication.logic.SearchResult
+import com.example.myapplication.logic.HybridSearchProvider
+import kotlinx.coroutines.launch
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.PolyUtil
 import com.example.myapplication.ui.models.BuildingUiState
+import com.google.android.libraries.places.api.net.PlacesClient
+import com.example.myapplication.ui.models.MapUIMode
+import com.example.myapplication.logic.RouteProvider
 
-class MapViewModel(private val locationProvider: LocationProvider? = null) : ViewModel() {
+class MapViewModel(
+    private val locationProvider: com.example.myapplication.logic.LocationProvider? = null,
+    private val routeProvider: com.example.myapplication.logic.RouteProvider? = null
+) : ViewModel() {
 
+
+
+    var searchQuery by mutableStateOf("")
+        private set
+
+    var searchResults by mutableStateOf<List<SearchResult>>(emptyList())
+        private set
+
+    private var searchProvider: HybridSearchProvider? = null
     private var isManualCampusSelection = false
     var uiBuildingState by mutableStateOf(BuildingUiState())
         private set
 
     fun handleMapTap(building: Building?, address: String? = null, imageUrl: String? = null) {
+        if (uiBuildingState.mode == MapUIMode.DIRECTIONS) return
         uiBuildingState = BuildingUiState(
             isVisible = building != null,
             building = building,
@@ -88,5 +109,216 @@ class MapViewModel(private val locationProvider: LocationProvider? = null) : Vie
             // User walked out of all known campuses; reset the lock
             isManualCampusSelection = false
         }
+    }
+
+    var mapEvent by mutableStateOf<LatLng?>(null)
+        private set
+
+    fun clearMapEvent() { mapEvent = null }
+
+    fun handleSearchResult(result: SearchResult, context: android.content.Context) {
+        val resultName = when (result) {
+            is SearchResult.BuildingResult -> result.building.name
+            is SearchResult.CampusResult -> result.campus.name
+            is SearchResult.GoogleResult -> result.title
+            is SearchResult.CurrentLocation -> "Your position"
+            is SearchResult.Home -> "Home"
+        }
+
+        val resultCoords = when (result) {
+            is SearchResult.BuildingResult -> result.building.getCenter()
+            is SearchResult.CampusResult -> result.campus.buildings.firstOrNull()?.getCenter()
+            is SearchResult.CurrentLocation -> lastProcessedLocation
+            is SearchResult.Home -> LatLng(45.51723868665001, -73.627297124046)
+            is SearchResult.GoogleResult -> null
+        }
+
+        if (uiBuildingState.mode == MapUIMode.DIRECTIONS) {
+            val selectedBuilding = if (result is SearchResult.BuildingResult) result.building else null
+
+            uiBuildingState = if (activeSearchField == "start") {
+                uiBuildingState.copy(
+                    startLocationName = resultName,
+                    startPoint = resultCoords // <--- Saved for route
+                )
+            } else {
+                uiBuildingState.copy(
+                    destinationName = resultName,
+                    building = selectedBuilding,
+                    endPoint = resultCoords // <--- Saved for route
+                )
+            }
+
+            // Camera move for directions selection
+            resultCoords?.let { setMapEventWithOffset(it) }
+
+            uiBuildingState = uiBuildingState.copy(isSearchExpanded = false)
+            // RECALCULATE ROUTE AUTOMATICALLY
+            calculateRoute()
+
+            searchResults = emptyList()
+            return
+        }
+
+        when (result) {
+
+            is SearchResult.CampusResult -> {
+                onCampusSelected(result.campus.name)
+
+                resultCoords?.let { setMapEventWithOffset(it) }
+
+                uiBuildingState = uiBuildingState.copy(
+                    isVisible = false,
+                    building = null
+                )
+            }
+
+            is SearchResult.BuildingResult -> {
+                val b = result.building
+                highlightedBuildingName = b.name
+
+                // Set endPoint in case they switch to directions later
+                uiBuildingState = uiBuildingState.copy(
+                    isVisible = true,
+                    building = b,
+                    endPoint = b.getCenter()
+                )
+
+                com.example.myapplication.logic.MapInteractionHandler.handleSearchSelection(
+                    b, this, context
+                )
+
+                CampusRepo.getAllCampuses().find { it.buildings.contains(b) }?.let {
+                    currentCampus = it
+                    isManualCampusSelection = true
+                }
+
+                b.getGoogleOutline().firstOrNull()?.let { mapEvent = it }
+            }
+            is SearchResult.CurrentLocation -> {
+                locationProvider?.getUserLocation { location ->
+                    location?.let {
+                        mapEvent = it
+                        processLocationUpdate(it, isForce = true)
+                        uiBuildingState = uiBuildingState.copy(startPoint = it)
+                    }
+                }
+            }
+            is SearchResult.Home -> {
+                val homePos = LatLng(45.51723868665001, -73.627297124046)
+                mapEvent = homePos
+                uiBuildingState = uiBuildingState.copy(startPoint = homePos)
+            }
+            is SearchResult.GoogleResult -> { /* Future implementation */ }
+        }
+        searchResults = emptyList()
+    }
+    fun initSearch(client: com.google.android.libraries.places.api.net.PlacesClient) {
+        searchProvider = HybridSearchProvider(client)
+        searchResults = listOf(SearchResult.CurrentLocation)
+    }
+
+    var activeSearchField by mutableStateOf("main")
+        private set
+
+    fun onSearchQueryChanged(newQuery: String, field: String = "main") {
+        activeSearchField = field
+
+        if (field == "main") {
+            searchQuery = newQuery
+        } else if (field == "start") {
+            uiBuildingState = uiBuildingState.copy(startLocationName = newQuery)
+        } else if (field == "dest") {
+            uiBuildingState = uiBuildingState.copy(destinationName = newQuery)
+        }
+
+        viewModelScope.launch {
+            searchProvider?.let { provider ->
+                searchResults = provider.search(newQuery)
+            }
+        }
+    }
+    fun onDirectionsRequested() {
+        uiBuildingState = uiBuildingState.copy(
+            mode = com.example.myapplication.ui.models.MapUIMode.DIRECTIONS,
+            destinationName = uiBuildingState.building?.name ?: ""
+        )
+    }
+
+    fun onBackToPreview() {
+        uiBuildingState = uiBuildingState.copy(
+            mode = com.example.myapplication.ui.models.MapUIMode.PREVIEW
+        )
+    }
+    fun onStartQueryChanged(newQuery: String) {
+        uiBuildingState = uiBuildingState.copy(startLocationName = newQuery)
+    }
+
+    fun onDestinationQueryChanged(newQuery: String) {
+        uiBuildingState = uiBuildingState.copy(destinationName = newQuery)
+    }
+
+    fun onTransportModeChanged(mode: String) {
+        uiBuildingState = uiBuildingState.copy(selectedTransportMode = mode)
+        calculateRoute()
+    }
+
+    fun calculateRoute() {
+
+        val start = uiBuildingState.startPoint ?: lastProcessedLocation ?: return
+
+        val end = uiBuildingState.endPoint ?: uiBuildingState.building?.getCenter() ?: return
+
+        viewModelScope.launch {
+            val routeData = routeProvider?.getRoute(start, end, uiBuildingState.selectedTransportMode)
+
+            if (routeData != null) {
+                val builder = com.google.android.gms.maps.model.LatLngBounds.Builder()
+                routeData.points.forEach { builder.include(it) }
+                val bounds = builder.build()
+
+                uiBuildingState = uiBuildingState.copy(
+                    routePoints = routeData.points,
+                    routeDuration = routeData.duration,
+                    routeDistance = routeData.distance,
+                    routeBounds = bounds
+                )
+            } else {
+                uiBuildingState = uiBuildingState.copy(
+                    routePoints = emptyList(),
+                    routeDuration = "-- min",
+                    routeDistance = "-- m",
+                    routeBounds = null
+                )
+            }
+        }
+    }
+
+    fun toggleSearchExpansion(expanded: Boolean, field: String = "main") {
+        activeSearchField = field
+        uiBuildingState = uiBuildingState.copy(isSearchExpanded = expanded)
+    }
+    fun swapLocations() {
+        val currentStartLatLng = uiBuildingState.startPoint ?: lastProcessedLocation
+        val currentDestLatLng = uiBuildingState.endPoint ?: uiBuildingState.building?.getCenter()
+
+        val currentDestBuilding = uiBuildingState.building
+        uiBuildingState = uiBuildingState.copy(
+            startLocationName = uiBuildingState.destinationName,
+            destinationName = uiBuildingState.startLocationName,
+            startPoint = currentDestLatLng,
+            endPoint = currentStartLatLng,
+            building = if (!uiBuildingState.isStartCurrentLocation) null else currentDestBuilding        )
+
+        uiBuildingState.endPoint?.let { setMapEventWithOffset(it) }
+
+        // Update the building highlight name for the renderer
+        highlightedBuildingName = uiBuildingState.building?.name
+
+        calculateRoute()
+    }
+    fun setMapEventWithOffset(target: LatLng) {
+        val offsetTarget = LatLng(target.latitude - 0.005, target.longitude)
+        mapEvent = offsetTarget
     }
 }

--- a/app/src/test/java/com/example/myapplication/CampusRepoTest.kt
+++ b/app/src/test/java/com/example/myapplication/CampusRepoTest.kt
@@ -49,7 +49,13 @@ class CampusRepoTest {
     @Test
     fun `getCampus identifies user inside a specific building even if campus outline is empty`() {
         val bOutline = listOf(JsonLatLng(0.0, 0.0), JsonLatLng(1.0, 0.0), JsonLatLng(1.0, 1.0), JsonLatLng(0.0, 1.0))
-        val building = Building("Hall", "H", 1L, bOutline)
+        val building = Building(
+            name = "Hall",
+            code = "H",
+            wayID = 22080570,
+            fullAddress = "1455 De Maisonneuve",
+            outline = emptyList()
+        )
         val campus = Campus("SGW", JsonLatLng(0.5, 0.5), listOf(building), emptyList())
 
         CampusRepo.setTestCampuses(listOf(campus))


### PR DESCRIPTION
## Summary
<!-- Briefly describe what the PR does -->

Comprehensive implementation of building selection and outdoor routing features. 
This commit completes the implementation of outdoor navigation features, closing US-2.1, US-2.2, and US-2.3. The system now supports comprehensive destination selection, real-time routing with transport mode variants, and a responsive camera system that manages UI overlays.

### Navigation & Search (US-2.1, US-2.2, 2.4)
- **Smart Dual-Input Navigation Header:** Implemented an expandable header that manages Start and Destination fields simultaneously with active focus-state management.
- **Predictive Search & Building Type-ahead:** Integrated a real-time search engine that filters campus buildings by name and code (e.g., "Hall", "H", "SGW") as the user types.
- **Contextual Location Defaults:** Added "Your position" (GPS-sync) and specialized quick-select options to the search results.
- **Dynamic Action Logic:** Implemented "START" vs "PREVIEW" button states that automatically toggle based on whether the origin matches the user's current GPS location.
- **Synchronized Location Swap:** Built a bidirectional swap feature that re-orders coordinates, names, and map markers in a single transaction.
- **Campus-Level Search Integration**: Expanded search provider to recognize "SGW" and "Loyola" as first-class results, allowing for instant campus switching and cross-campus route initialization.

### Routing & Visualization (US-2.3, 2.4)
- **Translucent "Glass" Directions Popup:** Designed a semi-transparent UI overlay providing route duration, distance, and transport mode toggles.
- **Advanced Route Visualization:**
    - Origin: Marked with a Blue Azure dot.
    - Destination: Marked with a Red Location Pin.
    - Polylines: Integrated context-aware styling (Dotted/Dashed for walking, Solid for driving/transit).
- **Responsive Camera & Padding Logic:** - Implemented `contentPadding` in the `CampusMap` to shift the map's logical center to the top half of the screen.
    - Adjusted `LatLngBounds` padding to ensure long routes (e.g., Loyola to SGW) remain fully visible above the UI popups.
    - Refined coordinate offset logic to prevent destination pins from being obscured by bottom-aligned overlays.

### UX & Map State Management
- **Map Focus Mode:** Automatically hides background UI elements (Campus Toggle/Recenter) and applies a background dim to highlight the navigation panel when in directions mode.
- **Building Highlighting:** Integrated destination-specific highlighting where the target building is filled with a distinct green outline and fill during active routing.
- **Automatic Route Recalculation:** The system triggers route updates immediately upon search result selection or transport mode change.
---

## Related Issue
<!-- Link the issue(s) this PR resolves -->
Closes #14
Closes #15
Closes #16
Closes #17
Closes #96
Closes #97
Closes #98
Closes #89
Closes #90
Closes #91
Closes #92
Closes #93
Closes #94
Closes #95

Closes #99 
Closes #100 
Closes #101 
Closes #102 
Closes #103 
Closes #105 

Resolves #78
Resolves #79
Resolves #81
Resolves #82
Resolves #83
Resolves #84
Resolves #85
Resolves #86
Resolves #87
Resolves #88

---

## How has this been tested?
<!-- Describe testing steps -->
- [ ] Unit tests
- [x] Manual testing
- [ ] End-to-end testing
- [ ] No test required

---

## Screenshots
<!-- Add screenshots here -->

<img width="334" height="704" alt="Screenshot 2026-02-25 at 09 59 24" src="https://github.com/user-attachments/assets/039348ad-f2e5-48a3-8806-bd76bb782e8a" />
<img width="339" height="707" alt="Screenshot 2026-02-25 at 10 00 22" src="https://github.com/user-attachments/assets/cfc4141b-0df9-4de4-8ace-516827076330" />
<img width="340" height="708" alt="Screenshot 2026-02-25 at 10 07 44" src="https://github.com/user-attachments/assets/e11bbcb7-397a-4132-b46d-89d4e0021b10" />
<img width="333" height="709" alt="Screenshot 2026-02-25 at 10 08 14" src="https://github.com/user-attachments/assets/26087b4e-2708-49ca-a0dc-e542636f0002" />
<img width="323" height="708" alt="Screenshot 2026-02-25 at 10 08 37" src="https://github.com/user-attachments/assets/e99a44fb-ec17-4ed4-a49a-7b0a6acba24e" />
<img width="325" height="696" alt="Screenshot 2026-02-25 at 11 16 02" src="https://github.com/user-attachments/assets/36baeb91-39c5-48ec-a707-678703a1f97c" />
<img width="336" height="708" alt="Screenshot 2026-02-25 at 11 14 20" src="https://github.com/user-attachments/assets/5f055e50-fe82-4ec4-9236-b6c2cbd4453e" />
<img width="327" height="700" alt="Screenshot 2026-02-25 at 12 54 39" src="https://github.com/user-attachments/assets/c36c3e60-162d-44f9-98e7-eab5299a58b6" />



---

## Checklist

- [x] I have provided a summary of my changes
- [x] I have specified the PR related issues
- [ ] I have tested implemented the required test for this code (if any)

---
