### PR TITLE
Update sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,20 +1,28 @@
 sonar.projectKey=soen-390-the-irs_backend
+
+
 sonar.organization=soen-390-the-irs
 
-# Main branch configuration
-sonar.branch.autoconfig.enabled=true
 
-# Sources - include both Java and Kotlin
-sonar.sources=app/src/main
+sonar.host.url=https://sonarcloud.io
 
-# Tests - include unit tests and instrumented tests
-sonar.tests=app/src/test
-# Binary files for analysis
-sonar.java.binaries=app/build/intermediates/classes/debug,app/build/intermediates/javac/debug/classes
 
-# Kotlin support
+sonar.sources=app/src/main/java
+
+
+sonar.tests=app/src/test/java
+
+
+sonar.java.binaries=app/build/intermediates/javac/debug/classes,app/build/intermediates/built_in_kotlinc/debug/compileDebugKotlin/classes
+
+
 sonar.kotlin.file.suffixes=.kt,.kts
 
-# Android-specific settings
+
+sonar.coverage.jacoco.xmlReportPaths=app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
+
+
 sonar.android.lint.report=app/build/reports/lint-results.xml
 
+
+sonar.verbose=true


### PR DESCRIPTION
## Summary
- `build.yml` ran `./gradlew build` which compiles but never executes tests or generates JaCoCo coverage reports.
- The SonarCloud CLI scanner was used instead of the Gradle `sonar` plugin, missing project-aware coverage paths.
- No `sonar.coverage.jacoco.xmlReportPaths` property was configured, so SonarCloud had no coverage data to ingest.
- **`.github/workflows/build.yml`**
- Replaced `./gradlew build` with `./gradlew jacocoTestReport` to generate coverage XML.
- Replaced `SonarSource/sonarcloud-github-action@master` with `./gradlew sonar` to use the Gradle plugin.
- Added `permissions: pull-requests: write` for PR comments.
- Removed hardcoded `-Dsonar.branch.name=main` arg (autoconfig handles this).


---

## Related Issue
<!-- Link the issue(s) this PR resolves -->
https://github.com/das-bhaskar/Conco-ordinates/issues/270
Closes #270 


---

## How has this been tested?
<!-- Describe testing steps -->
- [ ] Unit tests
- [ ] Manual testing
- [ ] End-to-end testing
- [ X] No test required

---

## Screenshots
<!-- Add screenshots here -->


---

## Checklist

- [ X] I have provided a summary of my changes
- [X ] I have specified the PR related issues
- [ ] I have tested implemented the required test for this code (if any)

---
