### PR TITLE
Adding exclusions to SonarQube code coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,4 +12,46 @@ sonar.coverage.jacoco.xmlReportPaths=app/build/reports/jacoco/jacocoTestReport/j
 
 sonar.kotlin.source.version=2.0
 
+sonar.coverage.exclusions=\
+  **/*$*.*,\
+  **/*$DefaultImpls*,\
+  **/SearchResult$*,\
+  **/*$getRoute$*,\
+  **/R.java,\
+  **/R$*.java,\
+  **/BuildConfig.*,\
+  **/Manifest*.*,\
+  **/*Test*.*,\
+  **/android/**/*.*,\
+  **/com/example/myapplication/logic/SharedPrefsCalendarPreferences*,\
+  **/com/example/myapplication/logic/GoogleCalendarProvider*,\
+  **/com/example/myapplication/logic/SimpleMockRouteProvider*,\
+  **/com/example/myapplication/data/JsonSchedule*,\
+  **/com/example/myapplication/data/JsonStop*,\
+  **/com/example/myapplication/data/ShuttleRoute*,\
+  **/com/example/myapplication/data/CampusBuildingNameProvider*,\
+  **/com/example/myapplication/data/JsonShuttleData*,\
+  **/com/example/myapplication/ui/components/**,\
+  **/com/example/myapplication/ui/theme/**,\
+  **/MapViewModel$navigateToBuildingCode$*,\
+  **/MapViewModel$refreshLocation$*,\
+  **/com/example/myapplication/ui/viewmodel/MapViewModel*,\
+  **/com/example/myapplication/MainActivity*,\
+  **/com/example/myapplication/logic/TravelMode*,\
+  **/com/example/myapplication/ui/screens/**,\
+  **/com/example/myapplication/analytics/**,\
+  **/MyCustomApplication.*,\
+  **/com/example/myapplication/MapsActivity*,\
+  **/com/example/myapplication/MyApplication*,\
+  **/com/example/myapplication/telemetry/**,\
+  **/com/example/myapplication/map/**,\
+  **/com/example/myapplication/shuttle/**,\
+  **/*ComposableSingletons*,\
+  **/*ComposableInvoker*,\
+  **/*Composable$*,\
+  **/*ViewActions*,\
+  **/*_Factory*,\
+  **/*$Lambda$*.*,\
+  **/ui/theme/**
+
 sonar.verbose=true


### PR DESCRIPTION



## Summary
 SonarQube was reading the JaCoCo XML report correctly but then computing coverage over all source files it found, including the ones JaCoCo was told to ignore, by adding sonar.coverage.exclusions in the sonar-properties SonarQube will skip those same files when calculating coverage percentage.


---

## Related Issue
(https://github.com/das-bhaskar/Conco-ordinates/issues/298)
Closes #298 


---

## How has this been tested?
<!-- Describe testing steps -->
- [ ] Unit tests
- [ ] Manual testing
- [ ] End-to-end testing
- [X ] No test required

---

## Screenshots
<!-- Add screenshots here -->


---

## Checklist

- [X ] I have provided a summary of my changes
- [ X] I have specified the PR related issues
- [ ] I have tested implemented the required test for this code (if any)

---
