### PR TITLE
Tests for Epic 4

### DIFF
--- a/app/src/test/java/com/example/myapplication/BuildingUiStateTest.kt
+++ b/app/src/test/java/com/example/myapplication/BuildingUiStateTest.kt
@@ -1,0 +1,79 @@
+package com.example.myapplication.ui.models
+
+import com.example.myapplication.data.Building
+import com.example.myapplication.data.JsonLatLng
+import com.example.myapplication.data.ShuttleAvailability
+import com.google.android.gms.maps.model.LatLng
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BuildingUiStateTest {
+
+    private val building = Building(
+        name = "Henry F. Hall Building",
+        code = "H",
+        wayID = 1L,
+        address = "1455 De Maisonneuve Blvd W",
+        outline = listOf(
+            JsonLatLng(45.496, -73.580),
+            JsonLatLng(45.498, -73.580),
+            JsonLatLng(45.498, -73.578)
+        )
+    )
+
+    @Test
+    fun `MapUIMode contains the expected modes`() {
+        assertEquals(listOf(MapUIMode.PREVIEW, MapUIMode.DIRECTIONS, MapUIMode.ACTIVE_NAVIGATION), MapUIMode.entries)
+    }
+
+    @Test
+    fun `BuildingUiState defaults match preview map state`() {
+        val state = BuildingUiState()
+        assertFalse(state.isVisible)
+        assertEquals(MapUIMode.PREVIEW, state.mode)
+        assertNull(state.building)
+        assertEquals("Your position", state.startLocationName)
+        assertEquals("", state.destinationName)
+        assertEquals("walk", state.selectedTransportMode)
+        assertEquals("-- min", state.routeDuration)
+        assertEquals("-- m", state.routeDistance)
+        assertFalse(state.hasIndoorMap)
+        assertEquals(ShuttleAvailability.ScheduleUnavailable, state.shuttleAvailability)
+        assertTrue(state.routePoints.isEmpty())
+        assertTrue(state.routeSegments.isEmpty())
+        assertTrue(state.shuttleStops.isEmpty())
+    }
+
+    @Test
+    fun `BuildingUiState copy updates route and keeps unrelated values`() {
+        val start = BuildingUiState(building = building, isVisible = true)
+        val updated = start.copy(
+            mode = MapUIMode.DIRECTIONS,
+            destinationName = "CC-101",
+            startPoint = LatLng(45.497, -73.579),
+            endPoint = LatLng(45.458, -73.640),
+            routeDurationSeconds = 600L,
+            routeDuration = "10 min",
+            routeDistance = "900 m",
+            hasIndoorMap = true
+        )
+
+        assertTrue(updated.isVisible)
+        assertEquals(building, updated.building)
+        assertEquals(MapUIMode.DIRECTIONS, updated.mode)
+        assertEquals("CC-101", updated.destinationName)
+        assertEquals(600L, updated.routeDurationSeconds)
+        assertEquals("10 min", updated.routeDuration)
+        assertEquals("900 m", updated.routeDistance)
+        assertTrue(updated.hasIndoorMap)
+    }
+
+    @Test
+    fun `BuildingUiState navState defaults are preserved`() {
+        val state = BuildingUiState()
+        assertEquals(NavigationState(), state.navState)
+    }
+}

--- a/app/src/test/java/com/example/myapplication/CrossFloorNavigatorAdvancedTest.kt
+++ b/app/src/test/java/com/example/myapplication/CrossFloorNavigatorAdvancedTest.kt
@@ -1,0 +1,158 @@
+package com.example.myapplication.logic
+
+import com.example.myapplication.data.indoor.IIndoorRepository
+import com.example.myapplication.data.indoor.IndoorEdge
+import com.example.myapplication.data.indoor.IndoorFloor
+import com.example.myapplication.data.indoor.IndoorNode
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class CrossFloorNavigatorAdvancedTest {
+
+    private fun node(
+        id: String,
+        x: Float,
+        y: Float,
+        type: String = "CORRIDOR",
+        groupId: String? = null
+    ) = IndoorNode(id = id, x = x, y = y, type = type, elevatorGroupId = groupId)
+
+    private fun edge(from: String, to: String, accessible: Boolean = true) =
+        IndoorEdge(from = from, to = to, accessible = accessible)
+
+    @Test
+    fun `navigate with ESCALATOR uses escalator when available`() = runTest {
+        val floor1 = IndoorFloor(
+            building = "H",
+            floor = 1,
+            nodes = listOf(
+                node("start", 0f, 0f),
+                node("es_f1", 1f, 0f, "ESCALATOR", "ES-A"),
+                node("el_f1", 3f, 0f, "ELEVATOR", "EL-A")
+            ),
+            edges = listOf(edge("start", "es_f1"), edge("start", "el_f1"))
+        )
+        val floor8 = IndoorFloor(
+            building = "H",
+            floor = 8,
+            nodes = listOf(
+                node("es_f8", 0f, 0f, "ESCALATOR", "ES-A"),
+                node("el_f8", 2f, 0f, "ELEVATOR", "EL-A"),
+                node("dest", 1f, 0f)
+            ),
+            edges = listOf(edge("es_f8", "dest"), edge("el_f8", "dest"))
+        )
+        val repo = mock<IIndoorRepository>()
+        runBlocking {
+            whenever(repo.getFloor("H", 1)).thenReturn(floor1)
+            whenever(repo.getFloor("H", 8)).thenReturn(floor8)
+        }
+
+        val steps = CrossFloorNavigator.navigate(repo, "H", 1, "start", 8, "dest", TransferPreference.ESCALATOR)
+
+        val change = steps[1] as CrossFloorNavigator.NavStep.ChangeFloor
+        assertEquals(CrossFloorNavigator.VIA_ESCALATOR, change.via)
+    }
+
+    @Test
+    fun `navigate with STAIRS uses staircase when available`() = runTest {
+        val floor1 = IndoorFloor(
+            building = "H",
+            floor = 1,
+            nodes = listOf(
+                node("start", 0f, 0f),
+                node("st_f1", 1f, 0f, "STAIRCASE", "ST-A")
+            ),
+            edges = listOf(edge("start", "st_f1"))
+        )
+        val floor8 = IndoorFloor(
+            building = "H",
+            floor = 8,
+            nodes = listOf(
+                node("st_f8", 0f, 0f, "STAIRCASE", "ST-A"),
+                node("dest", 1f, 0f)
+            ),
+            edges = listOf(edge("st_f8", "dest"))
+        )
+        val repo = mock<IIndoorRepository>()
+        runBlocking {
+            whenever(repo.getFloor("H", 1)).thenReturn(floor1)
+            whenever(repo.getFloor("H", 8)).thenReturn(floor8)
+        }
+
+        val steps = CrossFloorNavigator.navigate(repo, "H", 1, "start", 8, "dest", TransferPreference.STAIRS)
+
+        val change = steps[1] as CrossFloorNavigator.NavStep.ChangeFloor
+        assertEquals(CrossFloorNavigator.VIA_STAIRCASE, change.via)
+    }
+
+    @Test
+    fun `navigate with inaccessible elevator path returns empty in elevator only mode`() = runTest {
+        val floor1 = IndoorFloor(
+            building = "H",
+            floor = 1,
+            nodes = listOf(
+                node("start", 0f, 0f),
+                node("el_f1", 1f, 0f, "ELEVATOR", "EL-A")
+            ),
+            edges = listOf(edge("start", "el_f1", accessible = false))
+        )
+        val floor8 = IndoorFloor(
+            building = "H",
+            floor = 8,
+            nodes = listOf(
+                node("el_f8", 0f, 0f, "ELEVATOR", "EL-A"),
+                node("dest", 1f, 0f)
+            ),
+            edges = listOf(edge("el_f8", "dest"))
+        )
+        val repo = mock<IIndoorRepository>()
+        runBlocking {
+            whenever(repo.getFloor("H", 1)).thenReturn(floor1)
+            whenever(repo.getFloor("H", 8)).thenReturn(floor8)
+        }
+
+        val steps = CrossFloorNavigator.navigate(repo, "H", 1, "start", 8, "dest", TransferPreference.ELEVATOR_ONLY)
+
+        assertTrue(steps.isEmpty())
+    }
+
+    @Test
+    fun `navigate ANY chooses the shorter transfer pair`() = runTest {
+        val floor1 = IndoorFloor(
+            building = "H",
+            floor = 1,
+            nodes = listOf(
+                node("start", 0f, 0f),
+                node("el_near_f1", 0.2f, 0f, "ELEVATOR", "EL-NEAR"),
+                node("el_far_f1", 0.9f, 0f, "ELEVATOR", "EL-FAR")
+            ),
+            edges = listOf(edge("start", "el_near_f1"), edge("start", "el_far_f1"))
+        )
+        val floor8 = IndoorFloor(
+            building = "H",
+            floor = 8,
+            nodes = listOf(
+                node("el_near_f8", 0f, 0f, "ELEVATOR", "EL-NEAR"),
+                node("el_far_f8", 1f, 0f, "ELEVATOR", "EL-FAR"),
+                node("dest", 0.2f, 0f)
+            ),
+            edges = listOf(edge("el_near_f8", "dest"), edge("el_far_f8", "dest"))
+        )
+        val repo = mock<IIndoorRepository>()
+        runBlocking {
+            whenever(repo.getFloor("H", 1)).thenReturn(floor1)
+            whenever(repo.getFloor("H", 8)).thenReturn(floor8)
+        }
+
+        val steps = CrossFloorNavigator.navigate(repo, "H", 1, "start", 8, "dest", TransferPreference.ANY)
+
+        val change = steps[1] as CrossFloorNavigator.NavStep.ChangeFloor
+        assertEquals("el_near_f8", change.targetNodeId)
+    }
+}

--- a/app/src/test/java/com/example/myapplication/CrossFloorNavigatorPreferenceFallbackTest.kt
+++ b/app/src/test/java/com/example/myapplication/CrossFloorNavigatorPreferenceFallbackTest.kt
@@ -1,0 +1,89 @@
+package com.example.myapplication.logic
+
+import com.example.myapplication.data.indoor.IIndoorRepository
+import com.example.myapplication.data.indoor.IndoorEdge
+import com.example.myapplication.data.indoor.IndoorFloor
+import com.example.myapplication.data.indoor.IndoorNode
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class CrossFloorNavigatorPreferenceFallbackTest {
+
+    private fun node(
+        id: String,
+        x: Float,
+        y: Float,
+        type: String = "CORRIDOR",
+        groupId: String? = null
+    ) = IndoorNode(id = id, x = x, y = y, type = type, elevatorGroupId = groupId)
+
+    private fun edge(from: String, to: String) = IndoorEdge(from = from, to = to)
+
+    private val floor1 = IndoorFloor(
+        building = "H",
+        floor = 1,
+        nodes = listOf(
+            node("start", 0f, 0f),
+            node("el_f1", 1f, 0f, type = "ELEVATOR", groupId = "EL-A")
+        ),
+        edges = listOf(edge("start", "el_f1"))
+    )
+
+    private val floor8 = IndoorFloor(
+        building = "H",
+        floor = 8,
+        nodes = listOf(
+            node("el_f8", 0f, 0f, type = "ELEVATOR", groupId = "EL-A"),
+            node("dest", 1f, 0f)
+        ),
+        edges = listOf(edge("el_f8", "dest"))
+    )
+
+    private fun makeRepo(): IIndoorRepository {
+        val repo = mock<IIndoorRepository>()
+        runBlocking {
+            whenever(repo.getFloor("H", 1)).thenReturn(floor1)
+            whenever(repo.getFloor("H", 8)).thenReturn(floor8)
+        }
+        return repo
+    }
+
+    @Test
+    fun `navigate with ESCALATOR falls back to elevator when no escalator exists`() = runTest {
+        val steps = CrossFloorNavigator.navigate(
+            repo = makeRepo(),
+            building = "H",
+            startFloor = 1,
+            startNodeId = "start",
+            targetFloor = 8,
+            targetNodeId = "dest",
+            preference = TransferPreference.ESCALATOR
+        )
+
+        assertEquals(3, steps.size)
+        val change = steps[1] as CrossFloorNavigator.NavStep.ChangeFloor
+        assertEquals(CrossFloorNavigator.VIA_ELEVATOR, change.via)
+    }
+
+    @Test
+    fun `navigate with STAIRS falls back to elevator when no staircase exists`() = runTest {
+        val steps = CrossFloorNavigator.navigate(
+            repo = makeRepo(),
+            building = "H",
+            startFloor = 1,
+            startNodeId = "start",
+            targetFloor = 8,
+            targetNodeId = "dest",
+            preference = TransferPreference.STAIRS
+        )
+
+        assertTrue(steps.isNotEmpty())
+        val change = steps[1] as CrossFloorNavigator.NavStep.ChangeFloor
+        assertEquals(CrossFloorNavigator.VIA_ELEVATOR, change.via)
+    }
+}

--- a/app/src/test/java/com/example/myapplication/IndoorBuildingConfigDimsTest.kt
+++ b/app/src/test/java/com/example/myapplication/IndoorBuildingConfigDimsTest.kt
@@ -1,0 +1,27 @@
+package com.example.myapplication.data.indoor
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class IndoorBuildingConfigDimsTest {
+
+    @Test
+    fun `dimsFor returns expected dimensions for known building`() {
+        val dims = IndoorBuildingConfig.dimsFor("H")
+        assertEquals(70f, dims.widthM)
+        assertEquals(120f, dims.heightM)
+    }
+
+    @Test
+    fun `dimsFor is case insensitive`() {
+        assertEquals(IndoorBuildingConfig.dimsFor("CC"), IndoorBuildingConfig.dimsFor("cc"))
+        assertEquals(IndoorBuildingConfig.dimsFor("Mb"), IndoorBuildingConfig.dimsFor("MB"))
+    }
+
+    @Test
+    fun `dimsFor returns default dimensions for unknown building`() {
+        val dims = IndoorBuildingConfig.dimsFor("UNKNOWN")
+        assertEquals(60f, dims.widthM)
+        assertEquals(80f, dims.heightM)
+    }
+}

--- a/app/src/test/java/com/example/myapplication/IndoorEnumsTest.kt
+++ b/app/src/test/java/com/example/myapplication/IndoorEnumsTest.kt
@@ -1,0 +1,33 @@
+package com.example.myapplication.data.indoor
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class IndoorEnumsTest {
+
+    @Test
+    fun `RoomType fromRaw matches known values case insensitively`() {
+        assertEquals(RoomType.CLASSROOM, RoomType.fromRaw("classroom"))
+        assertEquals(RoomType.WASHROOM, RoomType.fromRaw("WASHROOM"))
+        assertEquals(RoomType.ESCALATOR, RoomType.fromRaw("Escalator"))
+    }
+
+    @Test
+    fun `RoomType fromRaw falls back to OTHER for unknown values`() {
+        assertEquals(RoomType.OTHER, RoomType.fromRaw("lab"))
+        assertEquals(RoomType.OTHER, RoomType.fromRaw(""))
+    }
+
+    @Test
+    fun `NodeType fromRaw matches known values case insensitively`() {
+        assertEquals(NodeType.CORRIDOR, NodeType.fromRaw("corridor"))
+        assertEquals(NodeType.ELEVATOR, NodeType.fromRaw("ELEVATOR"))
+        assertEquals(NodeType.STAIRCASE, NodeType.fromRaw("Staircase"))
+    }
+
+    @Test
+    fun `NodeType fromRaw falls back to CORRIDOR for unknown values`() {
+        assertEquals(NodeType.CORRIDOR, NodeType.fromRaw("door"))
+        assertEquals(NodeType.CORRIDOR, NodeType.fromRaw(""))
+    }
+}

--- a/app/src/test/java/com/example/myapplication/IndoorOutdoorRouterAdditionalTest.kt
+++ b/app/src/test/java/com/example/myapplication/IndoorOutdoorRouterAdditionalTest.kt
@@ -1,0 +1,136 @@
+package com.example.myapplication.logic
+
+import com.example.myapplication.data.indoor.BuildingEntrance
+import com.example.myapplication.data.indoor.BuildingEntrances
+import com.example.myapplication.data.indoor.IIndoorRepository
+import com.example.myapplication.data.indoor.IndoorEdge
+import com.example.myapplication.data.indoor.IndoorFloor
+import com.example.myapplication.data.indoor.IndoorNode
+import com.google.android.gms.maps.model.LatLng
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class IndoorOutdoorRouterAdditionalTest {
+
+    private fun node(id: String, x: Float, y: Float, type: String = "CORRIDOR", groupId: String? = null) =
+        IndoorNode(id = id, x = x, y = y, type = type, elevatorGroupId = groupId)
+
+    private fun edge(from: String, to: String) = IndoorEdge(from = from, to = to)
+
+    private val floor1 = IndoorFloor(
+        building = "H",
+        floor = 1,
+        nodes = listOf(
+            node("start", 0f, 0f),
+            node("dest", 1f, 0f),
+            node("el_f1", 2f, 0f, "ELEVATOR", "EL-A")
+        ),
+        edges = listOf(edge("start", "dest"), edge("dest", "el_f1"))
+    )
+
+    private val floor8 = IndoorFloor(
+        building = "H",
+        floor = 8,
+        nodes = listOf(
+            node("el_f8", 0f, 0f, "ELEVATOR", "EL-A"),
+            node("dest_f8", 1f, 0f)
+        ),
+        edges = listOf(edge("el_f8", "dest_f8"))
+    )
+
+    private val ccFloor1 = IndoorFloor(
+        building = "CC",
+        floor = 1,
+        nodes = listOf(node("cc-ent", 0f, 0f), node("cc-dest", 1f, 0f)),
+        edges = listOf(edge("cc-ent", "cc-dest"))
+    )
+
+    private val hEntrance = BuildingEntrance("node-h-ent", "H South Entrance", LatLng(45.496, -73.579), 1)
+    private val ccEntrance = BuildingEntrance("cc-ent", "CC East Entrance", LatLng(45.458, -73.640), 1)
+
+    private fun makeRepo(): IIndoorRepository {
+        val repo = mock<IIndoorRepository>()
+        runBlocking {
+            whenever(repo.getFloor(any(), any())).thenReturn(null)
+            whenever(repo.getFloor("H", 1)).thenReturn(floor1)
+            whenever(repo.getFloor("H", 8)).thenReturn(floor8)
+            whenever(repo.getFloor("CC", 1)).thenReturn(ccFloor1)
+        }
+        return repo
+    }
+
+    @Test
+    fun `buildRoute same floor uses destination label in walk instruction`() = runTest {
+        val route = IndoorOutdoorRouter.buildRoute(
+            repo = makeRepo(),
+            startBuilding = "H",
+            startFloor = 1,
+            startNodeId = "start",
+            destination = IndoorOutdoorRouter.IndoorDestination("H", 1, "dest", "Hall Destination"),
+            userGps = null,
+            entrances = BuildingEntrances(mapOf("H" to listOf(hEntrance)))
+        )
+
+        val walk = route.segments.single() as IndoorOutdoorRouter.Segment.IndoorWalk
+        assertEquals("Walk to Hall Destination", walk.instruction)
+    }
+
+    @Test
+    fun `buildRoute cross floor includes elevator instructions`() = runTest {
+        val route = IndoorOutdoorRouter.buildRoute(
+            repo = makeRepo(),
+            startBuilding = "H",
+            startFloor = 1,
+            startNodeId = "start",
+            destination = IndoorOutdoorRouter.IndoorDestination("H", 8, "dest_f8", "H-829"),
+            userGps = null,
+            entrances = BuildingEntrances(mapOf("H" to listOf(hEntrance)))
+        )
+
+        val firstWalk = route.segments[0] as IndoorOutdoorRouter.Segment.IndoorWalk
+        val change = route.segments[1] as IndoorOutdoorRouter.Segment.FloorChange
+        val finalWalk = route.segments[2] as IndoorOutdoorRouter.Segment.IndoorWalk
+
+        assertEquals("Walk to the elevator", firstWalk.instruction)
+        assertEquals("Take the elevator to floor 8", change.instruction)
+        assertEquals("Walk to H-829", finalWalk.instruction)
+    }
+
+    @Test
+    fun `buildRoute multi building uses building name in outdoor instruction`() = runTest {
+        val route = IndoorOutdoorRouter.buildRoute(
+            repo = makeRepo(),
+            startBuilding = "H",
+            startFloor = 1,
+            startNodeId = "start",
+            destination = IndoorOutdoorRouter.IndoorDestination("CC", 1, "cc-dest", "CC-111"),
+            userGps = null,
+            entrances = BuildingEntrances(mapOf("H" to listOf(hEntrance), "CC" to listOf(ccEntrance)))
+        )
+
+        val outdoor = route.segments.filterIsInstance<IndoorOutdoorRouter.Segment.OutdoorWalk>().first()
+        assertEquals("Walk to CC building", outdoor.instruction)
+    }
+
+    @Test
+    fun `buildRoute with missing start building exit still adds destination indoor segment`() = runTest {
+        val route = IndoorOutdoorRouter.buildRoute(
+            repo = makeRepo(),
+            startBuilding = "H",
+            startFloor = 1,
+            startNodeId = "start",
+            destination = IndoorOutdoorRouter.IndoorDestination("CC", 1, "cc-dest", "CC-111"),
+            userGps = null,
+            entrances = BuildingEntrances(mapOf("CC" to listOf(ccEntrance)))
+        )
+
+        assertTrue(route.segments.none { it is IndoorOutdoorRouter.Segment.OutdoorWalk })
+        assertTrue(route.segments.any { it is IndoorOutdoorRouter.Segment.IndoorWalk })
+    }
+}

--- a/app/src/test/java/com/example/myapplication/IndoorOutdoorRouterEdgeCasesTest.kt
+++ b/app/src/test/java/com/example/myapplication/IndoorOutdoorRouterEdgeCasesTest.kt
@@ -1,0 +1,103 @@
+package com.example.myapplication.logic
+
+import com.example.myapplication.data.indoor.BuildingEntrance
+import com.example.myapplication.data.indoor.BuildingEntrances
+import com.example.myapplication.data.indoor.IIndoorRepository
+import com.example.myapplication.data.indoor.IndoorEdge
+import com.example.myapplication.data.indoor.IndoorFloor
+import com.example.myapplication.data.indoor.IndoorNode
+import com.google.android.gms.maps.model.LatLng
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class IndoorOutdoorRouterEdgeCasesTest {
+
+    private fun node(id: String, x: Float, y: Float, type: String = "CORRIDOR", groupId: String? = null) =
+        IndoorNode(id = id, x = x, y = y, type = type, elevatorGroupId = groupId)
+
+    private fun edge(from: String, to: String) = IndoorEdge(from = from, to = to)
+
+    private val hFloor1 = IndoorFloor(
+        building = "H",
+        floor = 1,
+        nodes = listOf(node("start", 0f, 0f), node("exit", 1f, 0f)),
+        edges = listOf(edge("start", "exit"))
+    )
+
+    private val ccFloor1 = IndoorFloor(
+        building = "CC",
+        floor = 1,
+        nodes = listOf(node("entry", 0f, 0f), node("dest", 1f, 0f)),
+        edges = listOf(edge("entry", "dest"))
+    )
+
+    private val hEntrance = BuildingEntrance("exit", "H Exit", LatLng(45.496, -73.579), 1)
+    private val ccEntrance = BuildingEntrance("entry", "CC Entry", LatLng(45.458, -73.640), 1)
+
+    private fun repo(
+        hallFloor: IndoorFloor? = hFloor1,
+        ccFloor: IndoorFloor? = ccFloor1
+    ): IIndoorRepository {
+        val repo = mock<IIndoorRepository>()
+        runBlocking {
+            whenever(repo.getFloor(any(), any())).thenReturn(null)
+            whenever(repo.getFloor("H", 1)).thenReturn(hallFloor)
+            whenever(repo.getFloor("CC", 1)).thenReturn(ccFloor)
+        }
+        return repo
+    }
+
+    @Test
+    fun `buildRoute different buildings returns empty route when no entrances exist`() = runTest {
+        val route = IndoorOutdoorRouter.buildRoute(
+            repo = repo(),
+            startBuilding = "H",
+            startFloor = 1,
+            startNodeId = "start",
+            destination = IndoorOutdoorRouter.IndoorDestination("CC", 1, "dest", "CC-101"),
+            userGps = null,
+            entrances = BuildingEntrances()
+        )
+
+        assertTrue(route.segments.isEmpty())
+    }
+
+    @Test
+    fun `buildRoute different buildings returns only outdoor walk when floor data is missing on both sides`() = runTest {
+        val route = IndoorOutdoorRouter.buildRoute(
+            repo = repo(hallFloor = null, ccFloor = null),
+            startBuilding = "H",
+            startFloor = 1,
+            startNodeId = "start",
+            destination = IndoorOutdoorRouter.IndoorDestination("CC", 1, "dest", "CC-101"),
+            userGps = null,
+            entrances = BuildingEntrances(mapOf("H" to listOf(hEntrance), "CC" to listOf(ccEntrance)))
+        )
+
+        assertEquals(1, route.segments.size)
+        assertTrue(route.segments.single() is IndoorOutdoorRouter.Segment.OutdoorWalk)
+    }
+
+    @Test
+    fun `buildRoute different buildings returns start walk plus outdoor walk when destination floor data is missing`() = runTest {
+        val route = IndoorOutdoorRouter.buildRoute(
+            repo = repo(ccFloor = null),
+            startBuilding = "H",
+            startFloor = 1,
+            startNodeId = "start",
+            destination = IndoorOutdoorRouter.IndoorDestination("CC", 1, "dest", "CC-101"),
+            userGps = null,
+            entrances = BuildingEntrances(mapOf("H" to listOf(hEntrance), "CC" to listOf(ccEntrance)))
+        )
+
+        assertEquals(2, route.segments.size)
+        assertTrue(route.segments[0] is IndoorOutdoorRouter.Segment.IndoorWalk)
+        assertTrue(route.segments[1] is IndoorOutdoorRouter.Segment.OutdoorWalk)
+    }
+}

--- a/app/src/test/java/com/example/myapplication/IndoorRoomResolverDefaultsTest.kt
+++ b/app/src/test/java/com/example/myapplication/IndoorRoomResolverDefaultsTest.kt
@@ -1,0 +1,58 @@
+package com.example.myapplication.logic
+
+import androidx.compose.ui.geometry.Offset
+import com.example.myapplication.data.indoor.IIndoorRepository
+import com.example.myapplication.data.indoor.IndoorFloor
+import com.example.myapplication.data.indoor.IndoorNode
+import com.example.myapplication.data.indoor.IndoorRoom
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class IndoorRoomResolverDefaultsTest {
+
+    private fun room(id: String, label: String) = IndoorRoom(
+        id = id,
+        type = "classroom",
+        label = label,
+        polygon = listOf(Offset(0.5f, 0.5f))
+    )
+
+    private fun node(id: String, roomId: String? = null) =
+        IndoorNode(id = id, x = 0.5f, y = 0.5f, type = "ROOM", roomId = roomId)
+
+    @Test
+    fun `resolve uses default building floors when floors argument is omitted`() = runTest {
+        val repo = mock<IIndoorRepository>()
+        whenever(repo.getFloor(any(), any())).thenReturn(null)
+
+        val floor8 = IndoorFloor(
+            building = "H",
+            floor = 8,
+            rooms = listOf(room("H-8-829", "H-829")),
+            nodes = listOf(node("node-829", roomId = "H-8-829"))
+        )
+        whenever(repo.getFloor("H", 8)).thenReturn(floor8)
+
+        val result = IndoorRoomResolver.resolve(repo, "H", "829")
+
+        assertNotNull(result)
+        assertEquals(8, result!!.floor)
+        assertEquals("node-829", result.nodeId)
+    }
+
+    @Test
+    fun `resolve returns null for unknown building when default floor list is empty`() = runTest {
+        val repo = mock<IIndoorRepository>()
+        whenever(repo.getFloor(any(), any())).thenReturn(null)
+
+        val result = IndoorRoomResolver.resolve(repo, "UNKNOWN", "101")
+
+        assertNull(result)
+    }
+}

--- a/app/src/test/java/com/example/myapplication/SearchProviderFormatsTest.kt
+++ b/app/src/test/java/com/example/myapplication/SearchProviderFormatsTest.kt
@@ -1,0 +1,113 @@
+package com.example.myapplication.logic
+
+import androidx.compose.ui.geometry.Offset
+import com.example.myapplication.data.indoor.IIndoorRepository
+import com.example.myapplication.data.indoor.IndoorFloor
+import com.example.myapplication.data.indoor.IndoorNode
+import com.example.myapplication.data.indoor.IndoorRoom
+import com.google.android.libraries.places.api.net.PlacesClient
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class SearchProviderFormatsTest {
+
+    private lateinit var placesClient: PlacesClient
+    private lateinit var indoorRepo: IIndoorRepository
+    private lateinit var provider: HybridSearchProvider
+
+    @Before
+    fun setup() {
+        placesClient = mock()
+        indoorRepo = mock()
+        provider = HybridSearchProvider(placesClient, indoorRepo)
+    }
+
+    private fun room(id: String, label: String) = IndoorRoom(
+        id = id,
+        type = "classroom",
+        label = label,
+        polygon = listOf(Offset(0.5f, 0.5f))
+    )
+
+    private fun node(id: String, roomId: String? = null) =
+        IndoorNode(id = id, x = 0.5f, y = 0.5f, type = "ROOM", roomId = roomId)
+
+    @Test
+    fun `searchIndoorRooms supports query without separator`() = runTest {
+        val floor = IndoorFloor(
+            building = "H",
+            floor = 8,
+            rooms = listOf(room("H-8-829", "H-829")),
+            nodes = listOf(node("node-829", roomId = "H-8-829"))
+        )
+        whenever(indoorRepo.getFloor(any(), any())).thenReturn(null)
+        whenever(indoorRepo.getFloor("H", 8)).thenReturn(floor)
+
+        val results = provider.searchIndoorRooms("H829")
+
+        assertEquals(1, results.size)
+        assertEquals("H", results.first().buildingCode)
+    }
+
+    @Test
+    fun `searchIndoorRooms supports spaces and lowercase building code`() = runTest {
+        val floor = IndoorFloor(
+            building = "H",
+            floor = 8,
+            rooms = listOf(room("H-8-829", "H-829")),
+            nodes = listOf(node("node-829", roomId = "H-8-829"))
+        )
+        whenever(indoorRepo.getFloor(any(), any())).thenReturn(null)
+        whenever(indoorRepo.getFloor("H", 8)).thenReturn(floor)
+
+        val results = provider.searchIndoorRooms("h 829")
+
+        assertEquals(1, results.size)
+        assertEquals("H-8-829", results.first().roomId)
+    }
+
+    @Test
+    fun `searchIndoorRooms supports hyphenated room suffix`() = runTest {
+        val floor = IndoorFloor(
+            building = "H",
+            floor = 1,
+            rooms = listOf(room("H-1-112-2", "H-112-2")),
+            nodes = listOf(node("node-112-2", roomId = "H-1-112-2"))
+        )
+        whenever(indoorRepo.getFloor(any(), any())).thenReturn(null)
+        whenever(indoorRepo.getFloor("H", 1)).thenReturn(floor)
+
+        val results = provider.searchIndoorRooms("H-112-2")
+
+        assertEquals(1, results.size)
+        assertEquals("node-112-2", results.first().nodeId)
+    }
+
+    @Test
+    fun `searchIndoorRooms formats result label with building and floor`() = runTest {
+        val floor = IndoorFloor(
+            building = "CC",
+            floor = 1,
+            rooms = listOf(room("CC-1-101", "CC-101")),
+            nodes = listOf(node("node-101", roomId = "CC-1-101"))
+        )
+        whenever(indoorRepo.getFloor(any(), any())).thenReturn(null)
+        whenever(indoorRepo.getFloor("CC", 1)).thenReturn(floor)
+
+        val results = provider.searchIndoorRooms("CC101")
+
+        assertEquals("CC-101 · CC Floor 1", results.first().label)
+    }
+
+    @Test
+    fun `searchIndoorRooms returns empty when query does not match indoor pattern`() = runTest {
+        val results = provider.searchIndoorRooms("hall building")
+        assertTrue(results.isEmpty())
+    }
+}

--- a/app/src/test/java/com/example/myapplication/SearchResultBehaviorTest.kt
+++ b/app/src/test/java/com/example/myapplication/SearchResultBehaviorTest.kt
@@ -1,0 +1,97 @@
+package com.example.myapplication.logic
+
+import com.example.myapplication.data.Building
+import com.example.myapplication.data.Campus
+import com.example.myapplication.data.JsonLatLng
+import com.google.android.gms.maps.model.LatLng
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SearchResultBehaviorTest {
+
+    private val hall = Building(
+        name = "Henry F. Hall Building",
+        code = "H",
+        wayID = 1L,
+        address = "1455 De Maisonneuve Blvd W",
+        outline = listOf(
+            JsonLatLng(45.496, -73.580),
+            JsonLatLng(45.498, -73.580),
+            JsonLatLng(45.498, -73.578),
+            JsonLatLng(45.496, -73.578)
+        )
+    )
+
+    private val campus = Campus(
+        name = "SGW Campus",
+        center = JsonLatLng(45.497, -73.579),
+        buildings = listOf(hall),
+        outline = null
+    )
+
+    @Test
+    fun `displayName returns building name for BuildingResult`() {
+        assertEquals("Henry F. Hall Building", SearchResult.BuildingResult(hall).displayName)
+    }
+
+    @Test
+    fun `displayName returns campus name for CampusResult`() {
+        assertEquals("SGW Campus", SearchResult.CampusResult(campus).displayName)
+    }
+
+    @Test
+    fun `displayName returns title for GoogleResult`() {
+        assertEquals("Hall", SearchResult.GoogleResult("Hall", "Address", "place-id").displayName)
+    }
+
+    @Test
+    fun `displayName returns label for IndoorRoomResult`() {
+        val result = SearchResult.IndoorRoomResult("H", 8, "H-8-829", "node-829", "H-829 · H Floor 8")
+        assertEquals("H-829 · H Floor 8", result.displayName)
+    }
+
+    @Test
+    fun `displayName returns fixed labels for CurrentLocation and Home`() {
+        assertEquals("Your position", SearchResult.CurrentLocation.displayName)
+        assertEquals("Home", SearchResult.Home.displayName)
+    }
+
+    @Test
+    fun `coordinates returns building center for BuildingResult`() {
+        val expected = hall.getCenter()
+        val actual = SearchResult.BuildingResult(hall).coordinates(null)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `coordinates returns first building center for CampusResult`() {
+        val actual = SearchResult.CampusResult(campus).coordinates(null)
+        assertEquals(hall.getCenter(), actual)
+    }
+
+    @Test
+    fun `coordinates returns null for CampusResult with no buildings`() {
+        val emptyCampus = campus.copy(buildings = emptyList())
+        val actual = SearchResult.CampusResult(emptyCampus).coordinates(null)
+        assertNull(actual)
+    }
+
+    @Test
+    fun `coordinates returns current location for CurrentLocation`() {
+        val current = LatLng(45.5, -73.6)
+        assertEquals(current, SearchResult.CurrentLocation.coordinates(current))
+    }
+
+    @Test
+    fun `coordinates returns null for GoogleResult and IndoorRoomResult`() {
+        assertNull(SearchResult.GoogleResult("Hall", "Address", "place-id").coordinates(null))
+        assertNull(SearchResult.IndoorRoomResult("H", 8, "H-8-829", "node-829", "H-829").coordinates(null))
+    }
+
+    @Test
+    fun `coordinates returns fixed home coordinates for Home`() {
+        val home = SearchResult.Home.coordinates(null)
+        assertEquals(LatLng(45.51723868665001, -73.627297124046), home)
+    }
+}


### PR DESCRIPTION
Unit Tests for indoor navigation (Epic 4) in order to test and help with the coverage


## Summary
Adds new low-risk JVM unit tests to strengthen Epic 4 indoor-navigation coverage without changing production code. The new tests cover indoor room resolution defaults, transfer-preference routing behavior, inter-building indoor/outdoor routing edge cases, indoor enum/config behavior, and a few indoor-related search/state models.



---

## Related Issue

Closes # 391


---

## How has this been tested?
- [X] Unit tests
- [ ] Manual testing
- [ ] End-to-end testing
- [ ] No test required

---

## Checklist

- [X] I have provided a summary of my changes
- [X] I have specified the PR related issues
- [ ] I have tested implemented the required test for this code (if any)

---
