### PR TITLE
Additional Test Coverages

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -123,6 +123,7 @@ dependencies {
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     testImplementation("com.google.code.gson:gson:2.10.1")
+    testImplementation("org.json:json:20231013")
     testImplementation(libs.junit)
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")

--- a/app/src/test/java/com/example/myapplication/IndoorJsonParserTest.kt
+++ b/app/src/test/java/com/example/myapplication/IndoorJsonParserTest.kt
@@ -1,0 +1,340 @@
+package com.example.myapplication
+
+import com.example.myapplication.data.indoor.IndoorJsonParser
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [IndoorJsonParser].
+ *
+ * Validates parsing of raw JSONObjects into IndoorFloor domain models
+ * without requiring Android Context or file I/O.
+ */
+class IndoorJsonParserTest {
+
+    private lateinit var parser: IndoorJsonParser
+
+    @Before
+    fun setup() {
+        parser = IndoorJsonParser()
+    }
+
+    // ── Minimal / empty input ─────────────────────────────────────────────────
+
+    @Test
+    fun `parse empty object produces defaults`() {
+        val floor = parser.parse(JSONObject())
+        assertEquals("", floor.building)
+        assertEquals(1, floor.floor)
+        assertTrue(floor.rooms.isEmpty())
+        assertTrue(floor.corridors.isEmpty())
+        assertTrue(floor.nodes.isEmpty())
+        assertTrue(floor.edges.isEmpty())
+        assertTrue(floor.pois.isEmpty())
+        assertTrue(floor.entrances.isEmpty())
+    }
+
+    @Test
+    fun `parse reads building and floor`() {
+        val json = JSONObject()
+            .put("building", "H")
+            .put("floor", 8)
+        val floor = parser.parse(json)
+        assertEquals("H", floor.building)
+        assertEquals(8, floor.floor)
+    }
+
+    // ── Rooms ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `parse single room with all fields`() {
+        val roomJson = JSONObject()
+            .put("id", "H-820")
+            .put("type", "classroom")
+            .put("label", "Room 820")
+            .put("icon", "📚")
+            .put("accessible", true)
+            .put("polygon", JSONArray()
+                .put(JSONArray().put(0.1).put(0.2))
+                .put(JSONArray().put(0.3).put(0.4))
+            )
+
+        val json = JSONObject()
+            .put("building", "H")
+            .put("floor", 8)
+            .put("rooms", JSONArray().put(roomJson))
+
+        val floor = parser.parse(json)
+        assertEquals(1, floor.rooms.size)
+        val room = floor.rooms[0]
+        assertEquals("H-820", room.id)
+        assertEquals("classroom", room.type)
+        assertEquals("Room 820", room.label)
+        assertEquals("📚", room.icon)
+        assertTrue(room.accessible)
+        assertEquals(2, room.polygon.size)
+        assertEquals(0.1f, room.polygon[0].x, 0.001f)
+        assertEquals(0.2f, room.polygon[0].y, 0.001f)
+    }
+
+    @Test
+    fun `parse room with missing optional fields uses defaults`() {
+        val roomJson = JSONObject()
+            .put("id", "H-821")
+            .put("polygon", JSONArray())
+
+        val json = JSONObject()
+            .put("rooms", JSONArray().put(roomJson))
+
+        val floor = parser.parse(json)
+        val room = floor.rooms[0]
+        assertEquals("H-821", room.id)
+        assertEquals("other", room.type)
+        assertEquals("H-821", room.label) // defaults to id
+        assertNull(room.icon)             // blank icon → null
+        assertTrue(room.accessible)       // default true
+        assertTrue(room.polygon.isEmpty())
+    }
+
+    // ── Corridors ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `parse corridor`() {
+        val corridorJson = JSONObject()
+            .put("id", "corridor-1")
+            .put("polygon", JSONArray()
+                .put(JSONArray().put(0.0).put(0.0))
+                .put(JSONArray().put(1.0).put(1.0))
+            )
+
+        val json = JSONObject()
+            .put("corridors", JSONArray().put(corridorJson))
+
+        val floor = parser.parse(json)
+        assertEquals(1, floor.corridors.size)
+        assertEquals("corridor-1", floor.corridors[0].id)
+        assertEquals(2, floor.corridors[0].polygon.size)
+    }
+
+    // ── Nodes ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `parse node with all fields`() {
+        val nodeJson = JSONObject()
+            .put("id", "node-1")
+            .put("x", 50.5)
+            .put("y", 100.25)
+            .put("type", "ELEVATOR")
+            .put("roomId", "H-820")
+            .put("elevatorGroupId", "elevator-A")
+            .put("transferFloor", 9)
+            .put("transferNodeId", "node-9-1")
+            .put("accessible", false)
+
+        val json = JSONObject()
+            .put("nodes", JSONArray().put(nodeJson))
+
+        val floor = parser.parse(json)
+        assertEquals(1, floor.nodes.size)
+        val node = floor.nodes[0]
+        assertEquals("node-1", node.id)
+        assertEquals(50.5f, node.x, 0.01f)
+        assertEquals(100.25f, node.y, 0.01f)
+        assertEquals("ELEVATOR", node.type)
+        assertEquals("H-820", node.roomId)
+        assertEquals("elevator-A", node.elevatorGroupId)
+        assertEquals(9, node.transferFloor)
+        assertEquals("node-9-1", node.transferNodeId)
+        assertFalse(node.accessible)
+    }
+
+    @Test
+    fun `parse node with defaults`() {
+        val nodeJson = JSONObject()
+            .put("id", "node-2")
+
+        val json = JSONObject()
+            .put("nodes", JSONArray().put(nodeJson))
+
+        val floor = parser.parse(json)
+        val node = floor.nodes[0]
+        assertEquals("node-2", node.id)
+        assertEquals(0.0f, node.x, 0.01f)
+        assertEquals(0.0f, node.y, 0.01f)
+        assertEquals("CORRIDOR", node.type)
+        assertNull(node.roomId)
+        assertNull(node.elevatorGroupId)
+        assertNull(node.transferFloor)
+        assertNull(node.transferNodeId)
+        assertTrue(node.accessible)
+    }
+
+    // ── Edges ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `parse edge with all fields`() {
+        val edgeJson = JSONObject()
+            .put("from", "node-1")
+            .put("to", "node-2")
+            .put("weight", 2.5)
+            .put("surface", "ROUGH")
+            .put("accessible", false)
+
+        val json = JSONObject()
+            .put("edges", JSONArray().put(edgeJson))
+
+        val floor = parser.parse(json)
+        assertEquals(1, floor.edges.size)
+        val edge = floor.edges[0]
+        assertEquals("node-1", edge.from)
+        assertEquals("node-2", edge.to)
+        assertEquals(2.5f, edge.weight, 0.01f)
+        assertEquals("ROUGH", edge.surface)
+        assertFalse(edge.accessible)
+    }
+
+    @Test
+    fun `parse edge with defaults`() {
+        val edgeJson = JSONObject()
+            .put("from", "a")
+            .put("to", "b")
+
+        val json = JSONObject()
+            .put("edges", JSONArray().put(edgeJson))
+
+        val edge = parser.parse(json).edges[0]
+        assertEquals(1.0f, edge.weight, 0.01f)
+        assertEquals("SMOOTH", edge.surface)
+        assertTrue(edge.accessible)
+    }
+
+    // ── POIs ──────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `parse poi`() {
+        val poiJson = JSONObject()
+            .put("id", "poi-1")
+            .put("type", "washroom")
+            .put("label", "Men's Washroom")
+            .put("x", 10.0)
+            .put("y", 20.0)
+            .put("nodeId", "node-5")
+
+        val json = JSONObject()
+            .put("pois", JSONArray().put(poiJson))
+
+        val floor = parser.parse(json)
+        assertEquals(1, floor.pois.size)
+        val poi = floor.pois[0]
+        assertEquals("poi-1", poi.id)
+        assertEquals("washroom", poi.type)
+        assertEquals("Men's Washroom", poi.label)
+        assertEquals(10.0f, poi.x, 0.01f)
+        assertEquals(20.0f, poi.y, 0.01f)
+        assertEquals("node-5", poi.nodeId)
+    }
+
+    // ── Entrances ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `parse entrance`() {
+        val entranceJson = JSONObject()
+            .put("id", "entrance-1")
+            .put("label", "Main Entrance")
+            .put("x", 5.0)
+            .put("y", 15.0)
+            .put("nodeId", "node-10")
+            .put("floor", 1)
+
+        val json = JSONObject()
+            .put("entrances", JSONArray().put(entranceJson))
+
+        val floor = parser.parse(json)
+        assertEquals(1, floor.entrances.size)
+        val entrance = floor.entrances[0]
+        assertEquals("entrance-1", entrance.id)
+        assertEquals("Main Entrance", entrance.label)
+        assertEquals(5.0f, entrance.x, 0.01f)
+        assertEquals(15.0f, entrance.y, 0.01f)
+        assertEquals("node-10", entrance.nodeId)
+        assertEquals(1, entrance.floor)
+    }
+
+    @Test
+    fun `parse entrance with defaults`() {
+        val entranceJson = JSONObject()
+            .put("id", "entrance-2")
+
+        val json = JSONObject()
+            .put("entrances", JSONArray().put(entranceJson))
+
+        val entrance = parser.parse(json).entrances[0]
+        assertEquals("entrance-2", entrance.id)
+        assertEquals("", entrance.label)
+        assertEquals(0.0f, entrance.x, 0.01f)
+        assertEquals(0.0f, entrance.y, 0.01f)
+        assertEquals("", entrance.nodeId)
+        assertEquals(1, entrance.floor)
+    }
+
+    // ── Full floor ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `parse complete floor JSON`() {
+        val json = JSONObject()
+            .put("building", "MB")
+            .put("floor", 1)
+            .put("rooms", JSONArray().put(
+                JSONObject().put("id", "MB-S1.401").put("type", "classroom")
+                    .put("polygon", JSONArray()
+                        .put(JSONArray().put(0.0).put(0.0))
+                        .put(JSONArray().put(1.0).put(0.0))
+                        .put(JSONArray().put(1.0).put(1.0))
+                    )
+            ))
+            .put("corridors", JSONArray().put(
+                JSONObject().put("id", "c1").put("polygon", JSONArray())
+            ))
+            .put("nodes", JSONArray()
+                .put(JSONObject().put("id", "n1").put("x", 10).put("y", 20))
+                .put(JSONObject().put("id", "n2").put("x", 30).put("y", 40))
+            )
+            .put("edges", JSONArray().put(
+                JSONObject().put("from", "n1").put("to", "n2").put("weight", 1.5)
+            ))
+            .put("pois", JSONArray().put(
+                JSONObject().put("id", "p1").put("type", "washroom").put("label", "WC")
+                    .put("x", 5).put("y", 5)
+            ))
+            .put("entrances", JSONArray().put(
+                JSONObject().put("id", "e1").put("label", "Main").put("x", 0).put("y", 0)
+                    .put("nodeId", "n1").put("floor", 1)
+            ))
+
+        val floor = parser.parse(json)
+        assertEquals("MB", floor.building)
+        assertEquals(1, floor.floor)
+        assertEquals(1, floor.rooms.size)
+        assertEquals(1, floor.corridors.size)
+        assertEquals(2, floor.nodes.size)
+        assertEquals(1, floor.edges.size)
+        assertEquals(1, floor.pois.size)
+        assertEquals(1, floor.entrances.size)
+    }
+
+    // ── Multiple items ────────────────────────────────────────────────────────
+
+    @Test
+    fun `parse multiple rooms`() {
+        val rooms = JSONArray()
+            .put(JSONObject().put("id", "r1").put("polygon", JSONArray()))
+            .put(JSONObject().put("id", "r2").put("polygon", JSONArray()))
+            .put(JSONObject().put("id", "r3").put("polygon", JSONArray()))
+
+        val json = JSONObject().put("rooms", rooms)
+        assertEquals(3, parser.parse(json).rooms.size)
+    }
+}

--- a/app/src/test/java/com/example/myapplication/LocationResolverTest.kt
+++ b/app/src/test/java/com/example/myapplication/LocationResolverTest.kt
@@ -1,0 +1,223 @@
+package com.example.myapplication
+
+import com.example.myapplication.data.BuildingNameProvider
+import com.example.myapplication.data.LocationResult
+import com.example.myapplication.data.ParsedLocation
+import com.example.myapplication.logic.LocationResolver
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [LocationResolver].
+ *
+ * Uses a [FakeBuildingNameProvider] so tests run without CampusRepo / Android Context.
+ */
+class LocationResolverTest {
+
+    /** Minimal fixture — only the codes the tests reference. */
+    private class FakeBuildingNameProvider : BuildingNameProvider {
+        private val map = mapOf(
+            "MB" to "John Molson Building",
+            "H"  to "Henry F. Hall Building",
+            "EV" to "Engineering, CS and VA Integrated Complex",
+            "CC" to "Central Building",
+            "VL" to "Vanier Library"
+        )
+        override fun nameForCode(code: String): String? =
+            map[code.uppercase()]
+    }
+
+    private lateinit var resolver: LocationResolver
+
+    @Before
+    fun setup() {
+        resolver = LocationResolver(FakeBuildingNameProvider())
+    }
+
+    // ── null / blank ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `resolve returns Unknown for null input`() {
+        assertEquals(LocationResult.Unknown, resolver.resolve(null))
+    }
+
+    @Test
+    fun `resolve returns Unknown for blank string`() {
+        assertEquals(LocationResult.Unknown, resolver.resolve("   "))
+    }
+
+    @Test
+    fun `resolve returns Unknown for empty string`() {
+        assertEquals(LocationResult.Unknown, resolver.resolve(""))
+    }
+
+    // ── Online detection ──────────────────────────────────────────────────────
+
+    @Test
+    fun `resolve returns Online for literal online`() {
+        assertEquals(LocationResult.Online, resolver.resolve("online"))
+    }
+
+    @Test
+    fun `resolve returns Online for remote`() {
+        assertEquals(LocationResult.Online, resolver.resolve("remote"))
+    }
+
+    @Test
+    fun `resolve returns Online for string starting with Online`() {
+        assertEquals(LocationResult.Online, resolver.resolve("Online via Zoom"))
+    }
+
+    @Test
+    fun `resolve returns Online for zoom link`() {
+        assertEquals(LocationResult.Online, resolver.resolve("Join via Zoom"))
+    }
+
+    @Test
+    fun `resolve returns Online for webex link`() {
+        assertEquals(LocationResult.Online, resolver.resolve("WebEx meeting"))
+    }
+
+    @Test
+    fun `resolve returns Online for teams link`() {
+        assertEquals(LocationResult.Online, resolver.resolve("Microsoft Teams"))
+    }
+
+    // ── TBA / TBD detection ──────────────────────────────────────────────────
+
+    @Test
+    fun `resolve returns TBA for tba`() {
+        assertEquals(LocationResult.TBA, resolver.resolve("TBA"))
+    }
+
+    @Test
+    fun `resolve returns TBA for tbd`() {
+        assertEquals(LocationResult.TBA, resolver.resolve("TBD"))
+    }
+
+    @Test
+    fun `resolve returns TBA for to be announced`() {
+        assertEquals(LocationResult.TBA, resolver.resolve("to be announced"))
+    }
+
+    @Test
+    fun `resolve returns TBA for to be determined`() {
+        assertEquals(LocationResult.TBA, resolver.resolve("to be determined"))
+    }
+
+    // ── Short pattern: "MB S1.401 SGW" ───────────────────────────────────────
+
+    @Test
+    fun `resolve parses short SGW pattern`() {
+        val result = resolver.resolve("MB S1.401 SGW")
+        assertTrue(result is LocationResult.Known)
+        val loc = (result as LocationResult.Known).location
+        assertEquals("MB", loc.buildingCode)
+        assertEquals("John Molson Building", loc.buildingName)
+        assertEquals("S1.401", loc.roomCode)
+        assertEquals("Sir George Williams", loc.campus)
+    }
+
+    @Test
+    fun `resolve parses short LOY pattern`() {
+        val result = resolver.resolve("CC 310 LOY")
+        assertTrue(result is LocationResult.Known)
+        val loc = (result as LocationResult.Known).location
+        assertEquals("CC", loc.buildingCode)
+        assertEquals("Central Building", loc.buildingName)
+        assertEquals("310", loc.roomCode)
+        assertEquals("Loyola", loc.campus)
+    }
+
+    @Test
+    fun `resolve parses short EV pattern`() {
+        val result = resolver.resolve("EV 3.309 EV")
+        assertTrue(result is LocationResult.Known)
+        val loc = (result as LocationResult.Known).location
+        assertEquals("EV", loc.buildingCode)
+        assertEquals("Engineering, CS and VA Integrated Complex", loc.buildingName)
+        assertEquals("3.309", loc.roomCode)
+    }
+
+    @Test
+    fun `resolve parses single letter building code`() {
+        val result = resolver.resolve("H 535 SGW")
+        assertTrue(result is LocationResult.Known)
+        val loc = (result as LocationResult.Known).location
+        assertEquals("H", loc.buildingCode)
+        assertEquals("Henry F. Hall Building", loc.buildingName)
+        assertEquals("535", loc.roomCode)
+        assertEquals("Sir George Williams", loc.campus)
+    }
+
+    // ── Long / verbose pattern ───────────────────────────────────────────────
+
+    @Test
+    fun `resolve parses verbose SGW string with Rm notation`() {
+        val result = resolver.resolve("Sir George Williams Campus - H Rm 862")
+        assertTrue(result is LocationResult.Known)
+        val loc = (result as LocationResult.Known).location
+        assertEquals("H", loc.buildingCode)
+        assertEquals("862", loc.roomCode)
+        assertEquals("Sir George Williams", loc.campus)
+    }
+
+    @Test
+    fun `resolve parses string with LOY campus mention`() {
+        val result = resolver.resolve("Loyola Campus - VL Rm 101")
+        assertTrue(result is LocationResult.Known)
+        val loc = (result as LocationResult.Known).location
+        assertEquals("VL", loc.buildingCode)
+        assertEquals("101", loc.roomCode)
+        assertEquals("Loyola", loc.campus)
+    }
+
+    @Test
+    fun `resolve returns Unknown for unrecognised building in verbose format`() {
+        val result = resolver.resolve("Sir George Williams Campus - ZZZ Rm 100")
+        assertEquals(LocationResult.Unknown, result)
+    }
+
+    // ── parsedLocation convenience ───────────────────────────────────────────
+
+    @Test
+    fun `parsedLocation returns ParsedLocation for known input`() {
+        val parsed = resolver.parsedLocation("H 535 SGW")
+        assertNotNull(parsed)
+        assertEquals("H", parsed!!.buildingCode)
+    }
+
+    @Test
+    fun `parsedLocation returns null for online`() {
+        assertNull(resolver.parsedLocation("online"))
+    }
+
+    @Test
+    fun `parsedLocation returns null for null`() {
+        assertNull(resolver.parsedLocation(null))
+    }
+
+    @Test
+    fun `parsedLocation returns null for TBA`() {
+        assertNull(resolver.parsedLocation("TBA"))
+    }
+
+    // ── Edge cases ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `resolve trims whitespace before parsing`() {
+        val result = resolver.resolve("  MB S1.401 SGW  ")
+        assertTrue(result is LocationResult.Known)
+    }
+
+    @Test
+    fun `resolve handles ONLINE in mixed case`() {
+        assertEquals(LocationResult.Online, resolver.resolve("ONLINE"))
+    }
+
+    @Test
+    fun `resolve handles TBA in mixed case`() {
+        assertEquals(LocationResult.TBA, resolver.resolve("Tba"))
+    }
+}

--- a/app/src/test/java/com/example/myapplication/NavigationEngineAdditionalTest.kt
+++ b/app/src/test/java/com/example/myapplication/NavigationEngineAdditionalTest.kt
@@ -1,0 +1,100 @@
+package com.example.myapplication
+
+import com.example.myapplication.logic.CampusNavigationEngine
+import com.google.android.gms.maps.model.LatLng
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Additional edge-case tests for [CampusNavigationEngine].
+ */
+class NavigationEngineAdditionalTest {
+
+    private lateinit var engine: CampusNavigationEngine
+
+    @Before
+    fun setup() {
+        engine = CampusNavigationEngine()
+    }
+
+    // ── checkArrival edge cases ───────────────────────────────────────────────
+
+    @Test
+    fun `checkArrival returns true when user is exactly at destination`() {
+        val point = LatLng(45.4972, -73.5789)
+        assertTrue(engine.checkArrival(point, point))
+    }
+
+    @Test
+    fun `checkArrival returns false when user is just over 15 metres away`() {
+        // ~20m north
+        val dest = LatLng(45.4972, -73.5789)
+        val user = LatLng(45.49738, -73.5789)
+        assertFalse(engine.checkArrival(user, dest))
+    }
+
+    // ── checkArrivalWithBuilding edge cases ───────────────────────────────────
+
+    @Test
+    fun `checkArrivalWithBuilding with custom small radius rejects nearby point`() {
+        val center = LatLng(45.4972, -73.5789)
+        // ~3m away
+        val user = LatLng(45.49722, -73.5789)
+        assertTrue(engine.checkArrivalWithBuilding(user, center, radiusMetres = 50.0))
+        assertFalse(engine.checkArrivalWithBuilding(user, center, radiusMetres = 0.1))
+    }
+
+    @Test
+    fun `checkArrivalWithBuilding with very large radius accepts far point`() {
+        val center = LatLng(45.4972, -73.5789)
+        val farUser = LatLng(45.498, -73.579) // ~100m away
+        assertTrue(engine.checkArrivalWithBuilding(farUser, center, radiusMetres = 200.0))
+    }
+
+    // ── calculateBearing edge cases ──────────────────────────────────────────
+
+    @Test
+    fun `calculateBearing skips close points and targets far point`() {
+        val user = LatLng(45.4972, -73.5789)
+        // First point is <12m away, second is ~1km north
+        val route = listOf(
+            LatLng(45.49725, -73.5789),  // very close (~5m)
+            LatLng(45.507, -73.5789)     // ~1km north
+        )
+        val bearing = engine.calculateBearing(user, route, 90f)
+        // Should target the far point, not return currentBearing
+        assertNotEquals(90f, bearing, 1f)
+    }
+
+    @Test
+    fun `calculateBearing with all points close returns currentBearing`() {
+        val user = LatLng(45.4972, -73.5789)
+        val route = listOf(
+            LatLng(45.49721, -73.5789),
+            LatLng(45.49722, -73.5789)
+        )
+        val bearing = engine.calculateBearing(user, route, 180f)
+        assertEquals(180f, bearing, 0.01f)
+    }
+
+    @Test
+    fun `calculateBearing with single far point returns heading`() {
+        val user = LatLng(45.4972, -73.5789)
+        val route = listOf(LatLng(45.507, -73.579)) // ~1km north
+        val bearing = engine.calculateBearing(user, route, 0f)
+        // Heading to a point due north should be close to 0 (north)
+        assertTrue(bearing in -10f..10f)
+    }
+
+    // ── calculateNextInstruction ──────────────────────────────────────────────
+
+    @Test
+    fun `calculateNextInstruction returns expected text`() {
+        val result = engine.calculateNextInstruction(
+            LatLng(45.497, -73.579),
+            emptyList()
+        )
+        assertEquals("Proceed toward destination", result)
+    }
+}

--- a/app/src/test/java/com/example/myapplication/ParsedLocationPropertiesTest.kt
+++ b/app/src/test/java/com/example/myapplication/ParsedLocationPropertiesTest.kt
@@ -1,0 +1,92 @@
+package com.example.myapplication
+
+import com.example.myapplication.data.LocationResult
+import com.example.myapplication.data.ParsedLocation
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Tests for [ParsedLocation] computed properties and
+ * [LocationResult] sealed-class identity / equality.
+ */
+class ParsedLocationPropertiesTest {
+
+    // ── ParsedLocation computed properties ────────────────────────────────────
+
+    @Test
+    fun `roomDisplay formats as code-room`() {
+        val loc = ParsedLocation("H", "Henry F. Hall Building", "820", "Sir George Williams")
+        assertEquals("H-820", loc.roomDisplay)
+    }
+
+    @Test
+    fun `shortSummary includes name, room display, and campus`() {
+        val loc = ParsedLocation("MB", "John Molson Building", "S1.401", "Sir George Williams")
+        assertEquals("John Molson Building · MB-S1.401 · Sir George Williams", loc.shortSummary)
+    }
+
+    @Test
+    fun `roomDisplay handles empty room code`() {
+        val loc = ParsedLocation("H", "Hall Building", "", "SGW")
+        assertEquals("H-", loc.roomDisplay)
+    }
+
+    @Test
+    fun `data class equality works`() {
+        val a = ParsedLocation("H", "Hall", "820", "SGW")
+        val b = ParsedLocation("H", "Hall", "820", "SGW")
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun `data class inequality on different fields`() {
+        val a = ParsedLocation("H", "Hall", "820", "SGW")
+        val b = ParsedLocation("MB", "Molson", "100", "SGW")
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `copy changes only specified fields`() {
+        val original = ParsedLocation("H", "Hall", "820", "SGW")
+        val copied = original.copy(roomCode = "821")
+        assertEquals("H", copied.buildingCode)
+        assertEquals("821", copied.roomCode)
+    }
+
+    // ── LocationResult sealed class ───────────────────────────────────────────
+
+    @Test
+    fun `Known instances with same ParsedLocation are equal`() {
+        val loc = ParsedLocation("H", "Hall", "820", "SGW")
+        assertEquals(LocationResult.Known(loc), LocationResult.Known(loc))
+    }
+
+    @Test
+    fun `Online is a singleton`() {
+        assertSame(LocationResult.Online, LocationResult.Online)
+    }
+
+    @Test
+    fun `TBA is a singleton`() {
+        assertSame(LocationResult.TBA, LocationResult.TBA)
+    }
+
+    @Test
+    fun `Unknown is a singleton`() {
+        assertSame(LocationResult.Unknown, LocationResult.Unknown)
+    }
+
+    @Test
+    fun `different LocationResult subtypes are not equal`() {
+        assertNotEquals(LocationResult.Online as LocationResult, LocationResult.TBA as LocationResult)
+        assertNotEquals(LocationResult.Unknown as LocationResult, LocationResult.Online as LocationResult)
+    }
+
+    @Test
+    fun `Known location property is accessible`() {
+        val loc = ParsedLocation("EV", "EV Complex", "3.309", "SGW")
+        val result = LocationResult.Known(loc)
+        assertEquals(loc, result.location)
+    }
+}

--- a/app/src/test/java/com/example/myapplication/ResolvedCalendarEventAdditionalTest.kt
+++ b/app/src/test/java/com/example/myapplication/ResolvedCalendarEventAdditionalTest.kt
@@ -1,0 +1,161 @@
+package com.example.myapplication
+
+import com.example.myapplication.data.CalendarEvent
+import com.example.myapplication.data.LocationResult
+import com.example.myapplication.data.ParsedLocation
+import com.example.myapplication.data.ResolvedCalendarEvent
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Additional coverage for [ResolvedCalendarEvent]:
+ * - TBA case for destinationBuildingCode
+ * - Convenience delegate properties
+ * - Known with blank buildingCode fallback to raw location
+ * - Unknown with null/blank raw location
+ */
+class ResolvedCalendarEventAdditionalTest {
+
+    private val sampleEvent = CalendarEvent(
+        id = "evt-42",
+        title = "COMP 354 Lecture",
+        location = "H 820 SGW",
+        startTimeMs = 1_700_000_000L,
+        endTimeMs   = 1_700_003_600L,
+        calendarId = "cal-1"
+    )
+
+    private val knownLocation = LocationResult.Known(
+        ParsedLocation(
+            buildingCode = "H",
+            buildingName = "Henry F. Hall Building",
+            roomCode     = "820",
+            campus       = "Sir George Williams"
+        )
+    )
+
+    // ── destinationBuildingCode: TBA case ─────────────────────────────────────
+
+    @Test
+    fun `destinationBuildingCode is null for TBA event`() {
+        val resolved = ResolvedCalendarEvent(
+            event = sampleEvent,
+            locationResult = LocationResult.TBA
+        )
+        assertNull(resolved.destinationBuildingCode)
+    }
+
+    // ── destinationBuildingCode: Known with blank buildingCode ────────────────
+
+    @Test
+    fun `destinationBuildingCode falls back to raw location when buildingCode is blank`() {
+        val blankCodeLocation = LocationResult.Known(
+            ParsedLocation(
+                buildingCode = "",
+                buildingName = "",
+                roomCode     = "100",
+                campus       = "Loyola"
+            )
+        )
+        val resolved = ResolvedCalendarEvent(
+            event = sampleEvent.copy(location = "H 820 SGW"),
+            locationResult = blankCodeLocation
+        )
+        assertEquals("H 820 SGW", resolved.destinationBuildingCode)
+    }
+
+    // ── destinationBuildingCode: Unknown with null raw location ───────────────
+
+    @Test
+    fun `destinationBuildingCode is null when Unknown and raw location is null`() {
+        val resolved = ResolvedCalendarEvent(
+            event = sampleEvent.copy(location = null),
+            locationResult = LocationResult.Unknown
+        )
+        assertNull(resolved.destinationBuildingCode)
+    }
+
+    @Test
+    fun `destinationBuildingCode is null when Unknown and raw location is blank`() {
+        val resolved = ResolvedCalendarEvent(
+            event = sampleEvent.copy(location = "  "),
+            locationResult = LocationResult.Unknown
+        )
+        assertNull(resolved.destinationBuildingCode)
+    }
+
+    // ── Convenience delegate properties ───────────────────────────────────────
+
+    @Test
+    fun `id delegates to event id`() {
+        val resolved = ResolvedCalendarEvent(event = sampleEvent, locationResult = knownLocation)
+        assertEquals("evt-42", resolved.id)
+    }
+
+    @Test
+    fun `title delegates to event title`() {
+        val resolved = ResolvedCalendarEvent(event = sampleEvent, locationResult = knownLocation)
+        assertEquals("COMP 354 Lecture", resolved.title)
+    }
+
+    @Test
+    fun `location delegates to event location`() {
+        val resolved = ResolvedCalendarEvent(event = sampleEvent, locationResult = knownLocation)
+        assertEquals("H 820 SGW", resolved.location)
+    }
+
+    @Test
+    fun `startTimeMs delegates to event startTimeMs`() {
+        val resolved = ResolvedCalendarEvent(event = sampleEvent, locationResult = knownLocation)
+        assertEquals(1_700_000_000L, resolved.startTimeMs)
+    }
+
+    @Test
+    fun `endTimeMs delegates to event endTimeMs`() {
+        val resolved = ResolvedCalendarEvent(event = sampleEvent, locationResult = knownLocation)
+        assertEquals(1_700_003_600L, resolved.endTimeMs)
+    }
+
+    @Test
+    fun `calendarId delegates to event calendarId`() {
+        val resolved = ResolvedCalendarEvent(event = sampleEvent, locationResult = knownLocation)
+        assertEquals("cal-1", resolved.calendarId)
+    }
+
+    // ── parsedLocation ────────────────────────────────────────────────────────
+
+    @Test
+    fun `parsedLocation returns location for Known result`() {
+        val resolved = ResolvedCalendarEvent(event = sampleEvent, locationResult = knownLocation)
+        assertNotNull(resolved.parsedLocation)
+        assertEquals("H", resolved.parsedLocation!!.buildingCode)
+        assertEquals("820", resolved.parsedLocation!!.roomCode)
+    }
+
+    @Test
+    fun `parsedLocation is null for Online result`() {
+        val resolved = ResolvedCalendarEvent(
+            event = sampleEvent,
+            locationResult = LocationResult.Online
+        )
+        assertNull(resolved.parsedLocation)
+    }
+
+    @Test
+    fun `parsedLocation is null for TBA result`() {
+        val resolved = ResolvedCalendarEvent(
+            event = sampleEvent,
+            locationResult = LocationResult.TBA
+        )
+        assertNull(resolved.parsedLocation)
+    }
+
+    @Test
+    fun `parsedLocation is null for Unknown result`() {
+        val resolved = ResolvedCalendarEvent(
+            event = sampleEvent,
+            locationResult = LocationResult.Unknown
+        )
+        assertNull(resolved.parsedLocation)
+    }
+}

--- a/app/src/test/java/com/example/myapplication/TransferPreferenceTest.kt
+++ b/app/src/test/java/com/example/myapplication/TransferPreferenceTest.kt
@@ -1,0 +1,109 @@
+package com.example.myapplication
+
+import com.example.myapplication.logic.TransferPreference
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Unit tests for [TransferPreference] enum properties and lookup behaviour.
+ */
+class TransferPreferenceTest {
+
+    // ── Any ───────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `ANY label is Any (Shortest)`() {
+        assertEquals("Any (Shortest)", TransferPreference.ANY.label)
+    }
+
+    @Test
+    fun `ANY icon is shuffle emoji`() {
+        assertEquals("🔀", TransferPreference.ANY.icon)
+    }
+
+    @Test
+    fun `ANY primary includes all three transfer types`() {
+        assertEquals(
+            listOf("ELEVATOR", "ESCALATOR", "STAIRCASE"),
+            TransferPreference.ANY.primary
+        )
+    }
+
+    @Test
+    fun `ANY fallback is empty`() {
+        assertTrue(TransferPreference.ANY.fallback.isEmpty())
+    }
+
+    // ── Elevator Only ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `ELEVATOR_ONLY primary is elevator only`() {
+        assertEquals(listOf("ELEVATOR"), TransferPreference.ELEVATOR_ONLY.primary)
+    }
+
+    @Test
+    fun `ELEVATOR_ONLY fallback is empty`() {
+        assertTrue(TransferPreference.ELEVATOR_ONLY.fallback.isEmpty())
+    }
+
+    @Test
+    fun `ELEVATOR_ONLY label is Elevator`() {
+        assertEquals("Elevator", TransferPreference.ELEVATOR_ONLY.label)
+    }
+
+    // ── Escalator ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `ESCALATOR primary is escalator`() {
+        assertEquals(listOf("ESCALATOR"), TransferPreference.ESCALATOR.primary)
+    }
+
+    @Test
+    fun `ESCALATOR fallback is elevator`() {
+        assertEquals(listOf("ELEVATOR"), TransferPreference.ESCALATOR.fallback)
+    }
+
+    @Test
+    fun `ESCALATOR label and icon`() {
+        assertEquals("Escalator", TransferPreference.ESCALATOR.label)
+        assertEquals("↗", TransferPreference.ESCALATOR.icon)
+    }
+
+    // ── Stairs ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `STAIRS primary is staircase`() {
+        assertEquals(listOf("STAIRCASE"), TransferPreference.STAIRS.primary)
+    }
+
+    @Test
+    fun `STAIRS fallback is elevator`() {
+        assertEquals(listOf("ELEVATOR"), TransferPreference.STAIRS.fallback)
+    }
+
+    @Test
+    fun `STAIRS label and icon`() {
+        assertEquals("Stairs", TransferPreference.STAIRS.label)
+        assertEquals("🪜", TransferPreference.STAIRS.icon)
+    }
+
+    // ── Enum completeness ─────────────────────────────────────────────────────
+
+    @Test
+    fun `all four preferences are defined`() {
+        val values = TransferPreference.entries
+        assertEquals(4, values.size)
+        assertTrue(values.contains(TransferPreference.ANY))
+        assertTrue(values.contains(TransferPreference.ELEVATOR_ONLY))
+        assertTrue(values.contains(TransferPreference.ESCALATOR))
+        assertTrue(values.contains(TransferPreference.STAIRS))
+    }
+
+    @Test
+    fun `valueOf resolves by name`() {
+        assertEquals(TransferPreference.ANY, TransferPreference.valueOf("ANY"))
+        assertEquals(TransferPreference.ELEVATOR_ONLY, TransferPreference.valueOf("ELEVATOR_ONLY"))
+        assertEquals(TransferPreference.ESCALATOR, TransferPreference.valueOf("ESCALATOR"))
+        assertEquals(TransferPreference.STAIRS, TransferPreference.valueOf("STAIRS"))
+    }
+}


### PR DESCRIPTION

## Summary
LocationResolver was completely untested (dedicated file), now has 27 tests covering all parsing branches
IndoorJsonParser was completely untested, now has 14 tests (required adding org.json:json test dependency in build.gradle.kts) TransferPreference, was untested, now fully covered ResolvedCalendarEvent — had 3 tests, now has 17 total covering TBA + all delegate properties. 


---

## How has this been tested?
<!-- Describe testing steps -->
- [X] Unit tests
- [ ] Manual testing
- [ ] End-to-end testing
- [ ] No test required


---

## Checklist

- [X] I have provided a summary of my changes
- [X] I have specified the PR related issues
- [X] I have tested implemented the required test for this code (if any)

---
